### PR TITLE
翻译: 第 3 章 工单 v1（13 篇）+ /translate-next 自动化命令

### DIFF
--- a/.claude/commands/translate-next.md
+++ b/.claude/commands/translate-next.md
@@ -1,0 +1,88 @@
+---
+description: 翻译 README checklist 中下一个待翻文件，提交并推送
+allowed-tools: Bash, Read, Edit, Write, mcp__github__create_pull_request, mcp__github__list_pull_requests
+---
+
+# 翻译下一个待翻文件
+
+你正在为 "100 Exercises to Learn Rust" 做中文翻译，严格遵循仓库根目录 `CLAUDE.md` 中的规范。
+
+## 执行步骤
+
+### 1. 找到下一个待翻文件
+
+读取 `README.md`，找到**第一个** `- [ ] ⏸️` 开头的行。
+- 如果找不到任何 `- [ ] ⏸️`，说明全部翻译完成。直接输出 `✅ 全部翻译完成，无可执行任务` 并退出，**不做任何修改、不创建分支、不 push**。
+- 行格式形如 `- [ ] ⏸️ 02_basic_calculator/06_while.md`，提取相对路径 `02_basic_calculator/06_while.md`。
+
+### 2. 检查英文源文件
+
+英文源路径为 `book/src/<提取出的路径>`。
+- 如果文件不存在或不是 `.md`，输出 `⚠️ 源文件 book/src/<path> 不存在，跳过` 并退出。
+
+### 3. 切换到章节分支
+
+从路径第一段提取章节目录（例如 `02_basic_calculator`），分支名为 `translate/<chapter_dir>`。
+- 用 `git fetch origin main` 同步
+- 如果当前已经在该分支，继续
+- 否则：`git checkout -B translate/<chapter_dir> origin/main`（基于最新 main）
+
+如果上一次 push 后远程已更新，先 `git pull origin translate/<chapter_dir>` 避免冲突。
+
+### 4. 翻译文件
+
+读取英文源文件 `book/src/<path>`，按以下规范翻译：
+
+**强制规范**（参考 `CLAUDE.md` + 已翻译文件 `book/src/02_basic_calculator/06_while.md`、`book/src/02_basic_calculator/10_as_casting.md`）：
+
+- 标题格式：
+  - h1：`# 中文标题 (English Title)`，英文首字母大写
+  - 多部分章节：`# 中文，第 N 部分 (Title, part N)`
+  - h2/h3 中文术语后括号注释英文（首字母大写），例如 `## 进一步阅读` / `## 范围 (Ranges)`
+- 专业术语首次出现时 `中文 (english term)`，括号内英文小写
+- "Further reading" 章节统一译为 `## 进一步阅读`
+- 代码块、错误信息、`println!` 字符串中的代码标识符**保持原样**；`println!` 字符串里的自然语言**翻译**
+- 内部相对链接保持原样（如 `../05_ticket_v2/13_try_from.md`）
+- footnote `[^name]` 标记保持原样
+- 文件末尾追加：
+  ```
+  
+  > 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/<path>)
+  ```
+
+用 Write 工具覆盖 `book/src/<path>`。
+
+### 5. 更新 README.md checklist
+
+把对应行的 `- [ ] ⏸️` 替换为 `- [x] ✅`，路径保持不变。
+
+### 6. Commit & push
+
+- `git add book/src/<path> README.md`
+- 提交信息：
+  ```
+  翻译: <path>
+  
+  https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA
+  ```
+- `git push -u origin translate/<chapter_dir>`，失败重试 4 次（2s/4s/8s/16s 退避）
+
+### 7. 维护 draft PR
+
+用 `mcp__github__list_pull_requests` 检查 `head=tangivis:translate/<chapter_dir>` 是否已有 open PR。
+- 如果有：什么都不做（commit 已自动追加到 PR）
+- 如果无：用 `mcp__github__create_pull_request` 创建 **draft** PR：
+  - 标题：`翻译: 第 X 章（自动）`（X 是章节号，例如 03）
+  - body 简述本章范围 + `自动翻译，请章节完成后人工审查再合并` 提示
+
+### 8. 输出一行报告
+
+格式：`✅ 已翻译 <path>（章 X：M/N），分支 translate/<chapter_dir>`
+其中 M 是该章已完成数（README 中 `- [x] ✅ <chapter_dir>/` 计数），N 是该章总数。
+
+## 重要约束
+
+- **每次只翻译一个文件**，绝不批量
+- **不要 merge PR**，永远保持 draft
+- **不要切回 main 或其他分支**，章节分支独立工作
+- 如果翻译质量自我评估存疑（术语首次出现却找不到合理中文等），在文件末尾翻译完成后追加一行 HTML 注释 `<!-- TODO: 待审 - 原因 -->`，便于人工抽检

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@
 - [x] ✅ 02_basic_calculator/10_as_casting.md
 
 ### 第3章：工单 v1 (Ticket v1)
-- [ ] ⏸️ 03_ticket_v1/00_intro.md
-- [ ] ⏸️ 03_ticket_v1/01_struct.md
-- [ ] ⏸️ 03_ticket_v1/02_validation.md
-- [ ] ⏸️ 03_ticket_v1/03_modules.md
-- [ ] ⏸️ 03_ticket_v1/04_visibility.md
-- [ ] ⏸️ 03_ticket_v1/05_encapsulation.md
-- [ ] ⏸️ 03_ticket_v1/06_ownership.md
-- [ ] ⏸️ 03_ticket_v1/07_setters.md
-- [ ] ⏸️ 03_ticket_v1/08_stack.md
-- [ ] ⏸️ 03_ticket_v1/09_heap.md
-- [ ] ⏸️ 03_ticket_v1/10_references_in_memory.md
-- [ ] ⏸️ 03_ticket_v1/11_destructor.md
-- [ ] ⏸️ 03_ticket_v1/12_outro.md
+- [x] ✅ 03_ticket_v1/00_intro.md
+- [x] ✅ 03_ticket_v1/01_struct.md
+- [x] ✅ 03_ticket_v1/02_validation.md
+- [x] ✅ 03_ticket_v1/03_modules.md
+- [x] ✅ 03_ticket_v1/04_visibility.md
+- [x] ✅ 03_ticket_v1/05_encapsulation.md
+- [x] ✅ 03_ticket_v1/06_ownership.md
+- [x] ✅ 03_ticket_v1/07_setters.md
+- [x] ✅ 03_ticket_v1/08_stack.md
+- [x] ✅ 03_ticket_v1/09_heap.md
+- [x] ✅ 03_ticket_v1/10_references_in_memory.md
+- [x] ✅ 03_ticket_v1/11_destructor.md
+- [x] ✅ 03_ticket_v1/12_outro.md
 
 ### 第4章：特质 (Traits)
 - [ ] ⏸️ 04_traits/00_intro.md

--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -1,7 +1,7 @@
 # 欢迎
 
 > 🌏 **中文版说明**
-> 本书正在翻译中，当前进度约 14%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
+> 本书正在翻译中，当前进度约 27%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
 > 英文原版请访问 [rust-exercises.com](https://rust-exercises.com)。
 > 翻译问题请提交到 [GitHub Issues](https://github.com/tangivis/100-exercises-to-learn-rust/issues)。
 

--- a/book/src/03_ticket_v1/00_intro.md
+++ b/book/src/03_ticket_v1/00_intro.md
@@ -1,18 +1,17 @@
-# Modelling A Ticket
+# 工单建模 (Modelling a Ticket)
 
-The first chapter should have given you a good grasp over some of Rust's primitive types, operators and
-basic control flow constructs.\
-In this chapter we'll go one step further and cover what makes Rust truly unique: **ownership**.\
-Ownership is what enables Rust to be both memory-safe and performant, with no garbage collector.
+第一章应该已经让你对 Rust 的一些原始类型 (primitive type)、运算符 (operator) 和基本控制流结构有了不错的掌握。\
+本章我们要更进一步，讲解 Rust 真正与众不同的特性：**所有权 (ownership)**。\
+所有权 (ownership) 让 Rust 既能做到内存安全 (memory-safe)，又能保持高性能，且无需垃圾回收器 (garbage collector)。
 
-As our running example, we'll use a (JIRA-like) ticket, the kind you'd use to track bugs, features, or tasks in
-a software project.\
-We'll take a stab at modeling it in Rust. It'll be the first iteration—it won't be perfect nor very idiomatic
-by the end of the chapter. It'll be enough of a challenge though!\
-To move forward you'll have to pick up several new Rust concepts, such as:
+作为贯穿全章的示例，我们会使用一个（类似 JIRA 的）工单 (ticket)——你在软件项目中用来跟踪 bug、特性或任务的那种东西。\
+我们会尝试用 Rust 来对它建模。这是第一次迭代——到本章结束时，模型既不会完美，也不会非常符合习惯用法 (idiomatic)。但已经足够有挑战性了！\
+为了向前推进，你需要掌握若干新的 Rust 概念，例如：
 
-- `struct`s, one of Rust's ways to define custom types
-- Ownership, references and borrowing
-- Memory management: stack, heap, pointers, data layout, destructors
-- Modules and visibility
-- Strings
+- `struct`，Rust 中定义自定义类型的方式之一
+- 所有权 (ownership)、引用 (reference) 和借用 (borrowing)
+- 内存管理：栈 (stack)、堆 (heap)、指针 (pointer)、数据布局 (data layout)、析构函数 (destructor)
+- 模块 (module) 和可见性 (visibility)
+- 字符串 (string)
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/00_intro.md)

--- a/book/src/03_ticket_v1/01_struct.md
+++ b/book/src/03_ticket_v1/01_struct.md
@@ -1,20 +1,18 @@
-# Structs
+# 结构体 (Structs)
 
-We need to keep track of three pieces of information for each ticket:
+我们需要为每个工单 (ticket) 跟踪三项信息：
 
-- A title
-- A description
-- A status
+- 标题 (title)
+- 描述 (description)
+- 状态 (status)
 
-We can start by using a [`String`](https://doc.rust-lang.org/std/string/struct.String.html)
-to represent them. `String` is the type defined in Rust's standard library to represent
-[UTF-8 encoded](https://en.wikipedia.org/wiki/UTF-8) text.
+可以先用 [`String`](https://doc.rust-lang.org/std/string/struct.String.html) 来表示它们。`String` 是 Rust 标准库中定义的类型，用于表示 [UTF-8 编码](https://en.wikipedia.org/wiki/UTF-8) 的文本。
 
-But how do we **combine** these three pieces of information into a single entity?
+但我们怎么把这三项信息**组合**成一个单一实体呢？
 
-## Defining a `struct`
+## 定义 `struct`
 
-A `struct` defines a **new Rust type**.
+`struct`（结构体）定义一个**新的 Rust 类型**。
 
 ```rust
 struct Ticket {
@@ -24,14 +22,14 @@ struct Ticket {
 }
 ```
 
-A struct is quite similar to what you would call a class or an object in other programming languages.
+结构体 (struct) 跟其他编程语言中的"类 (class)"或"对象 (object)"很相似。
 
-## Defining fields
+## 定义字段 (Defining fields)
 
-The new type is built by combining other types as **fields**.\
-Each field must have a name and a type, separated by a colon, `:`. If there are multiple fields, they are separated by a comma, `,`.
+新类型由其他类型作为**字段 (field)** 组合而成。\
+每个字段必须有名字和类型，二者用冒号 `:` 分隔。如果有多个字段，则用逗号 `,` 分隔。
 
-Fields don't have to be of the same type, as you can see in the `Configuration` struct below:
+字段不必是同一类型，参见下面的 `Configuration` 结构体：
 
 ```rust
 struct Configuration {
@@ -40,12 +38,12 @@ struct Configuration {
 }
 ```
 
-## Instantiation
+## 实例化 (Instantiation)
 
-You can create an instance of a struct by specifying the values for each field:
+你可以通过为每个字段指定值来创建一个结构体实例：
 
 ```rust
-// Syntax: <StructName> { <field_name>: <value>, ... }
+// 语法：<结构体名> { <字段名>: <值>, ... }
 let ticket = Ticket {
     title: "Build a ticket system".into(),
     description: "A Kanban board".into(),
@@ -53,19 +51,19 @@ let ticket = Ticket {
 };
 ```
 
-## Accessing fields
+## 访问字段 (Accessing fields)
 
-You can access the fields of a struct using the `.` operator:
+你可以使用 `.` 运算符访问结构体的字段：
 
 ```rust
-// Field access
+// 字段访问
 let x = ticket.description;
 ```
 
-## Methods
+## 方法 (Methods)
 
-We can attach behaviour to our structs by defining **methods**.\
-Using the `Ticket` struct as an example:
+我们可以通过定义**方法 (method)** 来给结构体附加行为。\
+以 `Ticket` 结构体为例：
 
 ```rust
 impl Ticket {
@@ -74,35 +72,34 @@ impl Ticket {
     }
 }
 
-// Syntax:
-// impl <StructName> {
-//    fn <method_name>(<parameters>) -> <return_type> {
-//        // Method body
+// 语法：
+// impl <结构体名> {
+//    fn <方法名>(<参数>) -> <返回类型> {
+//        // 方法体
 //    }
 // }
 ```
 
-Methods are pretty similar to functions, with two key differences:
+方法 (method) 与函数 (function) 非常相似，但有两个关键区别：
 
-1. methods must be defined inside an **`impl` block**
-2. methods may use `self` as their first parameter.
-   `self` is a keyword and represents the instance of the struct the method is being called on.
+1. 方法必须定义在 **`impl` 块**内
+2. 方法可以使用 `self` 作为它的第一个参数。
+   `self` 是一个关键字，代表方法被调用时所在的结构体实例。
 
 ### `self`
 
-If a method takes `self` as its first parameter, it can be called using the **method call syntax**:
+如果方法的第一个参数是 `self`，可以使用**方法调用语法 (method call syntax)** 来调用：
 
 ```rust
-// Method call syntax: <instance>.<method_name>(<parameters>)
+// 方法调用语法：<实例>.<方法名>(<参数>)
 let is_open = ticket.is_open();
 ```
 
-This is the same calling syntax you used to perform saturating arithmetic operations on `u32` values
-in [the previous chapter](../02_basic_calculator/09_saturating.md).
+这与你在[上一章](../02_basic_calculator/09_saturating.md)中对 `u32` 值执行饱和算术运算时所用的调用语法是一样的。
 
-### Static methods
+### 静态方法 (Static methods)
 
-If a method doesn't take `self` as its first parameter, it's a **static method**.
+如果方法不以 `self` 作为第一个参数，那它就是**静态方法 (static method)**。
 
 ```rust
 struct Configuration {
@@ -111,29 +108,30 @@ struct Configuration {
 }
 
 impl Configuration {
-    // `default` is a static method on `Configuration`
+    // `default` 是 `Configuration` 上的静态方法
     fn default() -> Configuration {
         Configuration { version: 0, active: false }
     }
 }
 ```
 
-The only way to call a static method is by using the **function call syntax**:
+调用静态方法的唯一方式是使用**函数调用语法 (function call syntax)**：
 
 ```rust
-// Function call syntax: <StructName>::<method_name>(<parameters>)
+// 函数调用语法：<结构体名>::<方法名>(<参数>)
 let default_config = Configuration::default();
 ```
 
-### Equivalence
+### 等价性 (Equivalence)
 
-You can use the function call syntax even for methods that take `self` as their first parameter:
+即使方法的第一个参数是 `self`，你依然可以用函数调用语法来调用它：
 
 ```rust
-// Function call syntax:
-//   <StructName>::<method_name>(<instance>, <parameters>)
+// 函数调用语法：
+//   <结构体名>::<方法名>(<实例>, <参数>)
 let is_open = Ticket::is_open(ticket);
 ```
 
-The function call syntax makes it quite clear that `ticket` is being used as `self`, the first parameter of the method,
-but it's definitely more verbose. Prefer the method call syntax when possible.
+函数调用语法非常清楚地表明 `ticket` 被当作 `self`（方法的第一个参数）使用，但显然更冗长。可以的话还是优先使用方法调用语法。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/01_struct.md)

--- a/book/src/03_ticket_v1/02_validation.md
+++ b/book/src/03_ticket_v1/02_validation.md
@@ -1,6 +1,6 @@
-# Validation
+# 验证 (Validation)
 
-Let's go back to our ticket definition:
+让我们回到工单 (ticket) 的定义：
 
 ```rust
 struct Ticket {
@@ -10,12 +10,13 @@ struct Ticket {
 }
 ```
 
-We are using "raw" types for the fields of our `Ticket` struct.
-This means that users can create a ticket with an empty title, a suuuuuuuper long description or
-a nonsensical status (e.g. "Funny").\
-We can do better than that!
+我们对 `Ticket` 结构体的字段使用了"原始"类型。
+这意味着用户可以创建一个标题为空、描述超长、或者状态毫无意义（例如 "Funny"）的工单。\
+我们能做得更好！
 
-## Further reading
+## 进一步阅读
 
-- Check out [`String`'s documentation](https://doc.rust-lang.org/std/string/struct.String.html)
-  for a thorough overview of the methods it provides. You'll need it for the exercise!
+- 完整浏览一下 [`String` 的文档](https://doc.rust-lang.org/std/string/struct.String.html)，
+  了解它提供的方法。完成练习时你会用到它！
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/02_validation.md)

--- a/book/src/03_ticket_v1/03_modules.md
+++ b/book/src/03_ticket_v1/03_modules.md
@@ -1,17 +1,15 @@
-# Modules
+# 模块 (Modules)
 
-The `new` method you've just defined is trying to enforce some **constraints** on the field values for `Ticket`.
-But are those invariants really enforced? What prevents a developer from creating a `Ticket`
-without going through `Ticket::new`?
+你刚刚定义的 `new` 方法试图在 `Ticket` 的字段值上强制施加一些**约束 (constraint)**。
+但这些不变量 (invariant) 真的被强制执行了吗？是什么阻止开发者绕过 `Ticket::new` 来创建一个 `Ticket`？
 
-To get proper **encapsulation** you need to become familiar with two new concepts: **visibility** and **modules**.
-Let's start with modules.
+要实现真正的**封装 (encapsulation)**，你需要熟悉两个新概念：**可见性 (visibility)** 和**模块 (module)**。
+我们先从模块讲起。
 
-## What is a module?
+## 什么是模块？(What is a module?)
 
-In Rust a **module** is a way to group related code together, under a common namespace (i.e. the module's name).\
-You've already seen modules in action: the unit tests that verify the correctness of your code are defined in a
-different module, named `tests`.
+在 Rust 中，**模块 (module)** 是一种把相关代码聚合在一起、放在一个共同命名空间（即模块名）下的方式。\
+你已经见过模块的实际用法：用来验证代码正确性的单元测试 (unit test) 就定义在一个名为 `tests` 的独立模块中。
 
 ```rust
 #[cfg(test)]
@@ -20,105 +18,99 @@ mod tests {
 }
 ```
 
-## Inline modules
+## 内联模块 (Inline modules)
 
-The `tests` module above is an example of an **inline module**: the module declaration (`mod tests`) and the module
-contents (the stuff inside `{ ... }`) are next to each other.
+上面的 `tests` 模块是**内联模块 (inline module)** 的例子：模块声明 (`mod tests`) 和模块内容（`{ ... }` 内的部分）紧挨在一起。
 
-## Module tree
+## 模块树 (Module tree)
 
-Modules can be nested, forming a **tree** structure.\
-The root of the tree is the **crate** itself, which is the top-level module that contains all the other modules.
-For a library crate, the root module is usually `src/lib.rs` (unless its location has been customized).
-The root module is also known as the **crate root**.
+模块可以嵌套，从而形成一棵**树**结构。\
+树的根是 **crate** 本身，也就是包含所有其他模块的顶级模块。
+对于库 crate (library crate)，根模块通常是 `src/lib.rs`（除非自定义了它的位置）。
+根模块也叫作 **crate 根 (crate root)**。
 
-The crate root can have submodules, which in turn can have their own submodules, and so on.
+crate 根可以有子模块，子模块还可以再有自己的子模块，依此类推。
 
-## External modules and the filesystem
+## 外部模块与文件系统 (External modules and the filesystem)
 
-Inline modules are useful for small pieces of code, but as your project grows you'll want to split your code into
-multiple files. In the parent module, you declare the existence of a submodule using the `mod` keyword.
+内联模块适合放小段代码，但项目变大后，你会想把代码拆到多个文件中。在父模块里，你用 `mod` 关键字声明子模块的存在。
 
 ```rust
 mod dog;
 ```
 
-`cargo`, Rust's build tool, is then in charge of finding the file that contains
-the module implementation.\
-If your module is declared in the root of your crate (e.g. `src/lib.rs` or `src/main.rs`),
-`cargo` expects the file to be named either:
+接下来，由 Rust 的构建工具 `cargo` 负责找到包含模块实现的文件。\
+如果你的模块声明在 crate 根（例如 `src/lib.rs` 或 `src/main.rs`），`cargo` 期待文件名是以下之一：
 
-- `src/<module_name>.rs`
-- `src/<module_name>/mod.rs`
+- `src/<模块名>.rs`
+- `src/<模块名>/mod.rs`
 
-If your module is a submodule of another module, the file should be named:
+如果你的模块是另一个模块的子模块，文件应当命名为：
 
-- `[..]/<parent_module>/<module_name>.rs`
-- `[..]/<parent_module>/<module_name>/mod.rs`
+- `[..]/<父模块>/<模块名>.rs`
+- `[..]/<父模块>/<模块名>/mod.rs`
 
-E.g. `src/animals/dog.rs` or `src/animals/dog/mod.rs` if `dog` is a submodule of `animals`.
+例如，如果 `dog` 是 `animals` 的子模块，则路径为 `src/animals/dog.rs` 或 `src/animals/dog/mod.rs`。
 
-Your IDE might help you create these files automatically when you declare a new module using the `mod` keyword.
+当你用 `mod` 关键字声明新模块时，IDE 通常会帮你自动创建这些文件。
 
-## Item paths and `use` statements
+## 项目路径与 `use` 语句 (Item paths and `use` statements)
 
-You can access items defined in the same module without any special syntax. You just use their name.
+在同一模块内访问已定义的项 (item) 不需要任何特殊语法，直接用名字即可。
 
 ```rust
 struct Ticket {
     // [...]
 }
 
-// No need to qualify `Ticket` in any way here
-// because we're in the same module
+// 这里不需要对 `Ticket` 做任何限定
+// 因为我们处于同一个模块中
 fn mark_ticket_as_done(ticket: Ticket) {
     // [...]
 }
 ```
 
-That's not the case if you want to access an entity from a different module.\
-You have to use a **path** pointing to the entity you want to access.
+但要访问另一个模块中的实体，情况就不一样了。\
+你必须使用一个**路径 (path)** 来指向想访问的实体。
 
-You can compose the path in various ways:
+可以用多种方式组合路径：
 
-- starting from the root of the current crate, e.g. `crate::module_1::MyStruct`
-- starting from the parent module, e.g. `super::my_function`
-- starting from the current module, e.g. `sub_module_1::MyStruct`
+- 从当前 crate 的根开始，例如 `crate::module_1::MyStruct`
+- 从父模块开始，例如 `super::my_function`
+- 从当前模块开始，例如 `sub_module_1::MyStruct`
 
-Both `crate` and `super` are **keywords**.\
-`crate` refers to the root of the current crate, while `super` refers to the parent of the current module.
+`crate` 和 `super` 都是**关键字**。\
+`crate` 指向当前 crate 的根；`super` 指向当前模块的父模块。
 
-Having to write the full path every time you want to refer to a type can be cumbersome.
-To make your life easier, you can introduce a `use` statement to bring the entity into scope.
+每次都要写完整路径会很啰嗦。
+为了让你的生活更轻松，可以用 `use` 语句把实体引入作用域 (scope)。
 
 ```rust
-// Bring `MyStruct` into scope
+// 把 `MyStruct` 引入作用域
 use crate::module_1::module_2::MyStruct;
 
-// Now you can refer to `MyStruct` directly
+// 现在可以直接使用 `MyStruct`
 fn a_function(s: MyStruct) {
      // [...]
 }
 ```
 
-### Star imports
+### 星号导入 (Star imports)
 
-You can also import all the items from a module with a single `use` statement.
+也可以用一条 `use` 语句导入模块中的所有项。
 
 ```rust
 use crate::module_1::module_2::*;
 ```
 
-This is known as a **star import**.\
-It is generally discouraged because it can pollute the current namespace, making it hard to understand
-where each name comes from and potentially introducing name conflicts.\
-Nonetheless, it can be useful in some cases, like when writing unit tests. You might have noticed
-that most of our test modules start with a `use super::*;` statement to bring all the items from the parent module
-(the one being tested) into scope.
+这种用法称为**星号导入 (star import)**。\
+通常不建议使用，因为它会污染当前命名空间，让人难以分辨每个名字的来源，还可能引入命名冲突。\
+不过在某些场景下它仍然有用，比如写单元测试时。你可能注意到我们大部分测试模块开头都有一句 `use super::*;`，把父模块（被测模块）中的所有项引入作用域。
 
-## Visualizing the module tree
+## 可视化模块树 (Visualizing the module tree)
 
-If you're struggling to picture the module tree of your project, you can try using
-[`cargo-modules`](https://crates.io/crates/cargo-modules) to visualize it!
+如果你很难想象项目的模块树，可以试试用 [`cargo-modules`](https://crates.io/crates/cargo-modules) 来可视化它！
 
-Refer to their documentation for installation instructions and usage examples.
+具体的安装与使用方法请参考其文档。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/03_modules.md)

--- a/book/src/03_ticket_v1/04_visibility.md
+++ b/book/src/03_ticket_v1/04_visibility.md
@@ -1,38 +1,33 @@
-# Visibility
+# 可见性 (Visibility)
 
-When you start breaking down your code into multiple modules, you need to start thinking about **visibility**.
-Visibility determines which regions of your code (or other people's code) can access a given entity,
-be it a struct, a function, a field, etc.
+当你开始把代码拆分成多个模块时，就需要考虑**可见性 (visibility)** 了。
+可见性决定了哪些代码区域（你的或别人的）可以访问某个实体——无论它是结构体、函数、字段还是其他东西。
 
-## Private by default
+## 默认私有 (Private by default)
 
-By default, everything in Rust is **private**.\
-A private entity can only be accessed:
+默认情况下，Rust 中的所有内容都是**私有 (private)** 的。\
+私有实体只能在以下范围内访问：
 
-1. within the same module where it's defined, or
-2. by one of its submodules
+1. 在它定义所在的同一模块内，或
+2. 该模块的某个子模块内
 
-We've used this extensively in the previous exercises:
+我们在前面的练习中已经大量用到这点：
 
-- `create_todo_ticket` worked (once you added a `use` statement) because `helpers` is a submodule of the crate root,
-  where `Ticket` is defined. Therefore, `create_todo_ticket` can access `Ticket` without any issues even
-  though `Ticket` is private.
-- All our unit tests are defined in a submodule of the code they're testing, so they can access everything without
-  restrictions.
+- `create_todo_ticket` 能够运行（在你加上 `use` 语句之后），是因为 `helpers` 是 crate 根的子模块，而 `Ticket` 就定义在 crate 根中。因此 `create_todo_ticket` 即使在 `Ticket` 是私有的情况下也能毫无问题地访问到它。
+- 我们所有的单元测试都定义在被测代码的子模块中，因此它们能不受限制地访问任何东西。
 
-## Visibility modifiers
+## 可见性修饰符 (Visibility modifiers)
 
-You can modify the default visibility of an entity using a **visibility modifier**.\
-Some common visibility modifiers are:
+你可以用**可见性修饰符 (visibility modifier)** 来修改实体的默认可见性。\
+一些常见的可见性修饰符是：
 
-- `pub`: makes the entity **public**, i.e. accessible from outside the module where it's defined, potentially from
-  other crates.
-- `pub(crate)`: makes the entity public within the same **crate**, but not outside of it.
-- `pub(super)`: makes the entity public within the parent module.
-- `pub(in path::to::module)`: makes the entity public within the specified module.
+- `pub`：将实体设为**公有 (public)**，即可以从定义所在模块的外部访问，潜在地包括其他 crate。
+- `pub(crate)`：在同一 **crate** 内公开，但不暴露给 crate 外部。
+- `pub(super)`：在父模块中公开。
+- `pub(in path::to::module)`：在指定的模块中公开。
 
-You can use these modifiers on modules, structs, functions, fields, etc.
-For example:
+这些修饰符可以用在模块、结构体、函数、字段等之上。
+例如：
 
 ```rust
 pub struct Configuration {
@@ -41,5 +36,7 @@ pub struct Configuration {
 }
 ```
 
-`Configuration` is public, but you can only access the `version` field from within the same crate.
-The `active` field, instead, is private and can only be accessed from within the same module or one of its submodules.
+`Configuration` 是公有的，但你只能在同一 crate 内访问 `version` 字段。
+而 `active` 字段是私有的，只能在同一模块或其子模块中访问。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/04_visibility.md)

--- a/book/src/03_ticket_v1/05_encapsulation.md
+++ b/book/src/03_ticket_v1/05_encapsulation.md
@@ -1,10 +1,9 @@
-# Encapsulation
+# 封装 (Encapsulation)
 
-Now that we have a basic understanding of modules and visibility, let's circle back to **encapsulation**.\
-Encapsulation is the practice of hiding the internal representation of an object. It is most commonly
-used to enforce some **invariants** on the object's state.
+现在我们对模块 (module) 和可见性 (visibility) 有了基本的理解，让我们回到**封装 (encapsulation)** 这个话题。\
+封装是指隐藏对象内部表示 (internal representation) 的实践。它最常见的用途是在对象状态上强制施加一些**不变量 (invariant)**。
 
-Going back to our `Ticket` struct:
+回到我们的 `Ticket` 结构体：
 
 ```rust
 struct Ticket {
@@ -14,20 +13,17 @@ struct Ticket {
 }
 ```
 
-If all fields are made public, there is no encapsulation.\
-You must assume that the fields can be modified at any time, set to any value that's allowed by
-their type. You can't rule out that a ticket might have an empty title or a status
-that doesn't make sense.
+如果所有字段都设为公有，就完全没有封装可言。\
+你必须假设字段随时可能被修改，可以被设为类型允许的任何值。你无法排除工单标题为空、或者状态毫无意义的可能性。
 
-To enforce stricter rules, we must keep the fields private[^newtype].
-We can then provide public methods to interact with a `Ticket` instance.
-Those public methods will have the responsibility of upholding our invariants (e.g. a title must not be empty).
+要执行更严格的规则，我们必须把字段保持为私有[^newtype]。
+然后我们提供公有方法来与 `Ticket` 实例交互。
+这些公有方法负责维护我们的不变量（例如：标题不能为空）。
 
-If at least one field is private it is no longer possible to create a `Ticket` instance directly using the struct
-instantiation syntax:
+只要至少有一个字段是私有的，就不再可能用结构体实例化语法直接创建 `Ticket` 实例：
 
 ```rust
-// This won't work!
+// 这无法工作！
 let ticket = Ticket {
     title: "Build a ticket system".into(),
     description: "A Kanban board".into(),
@@ -35,25 +31,26 @@ let ticket = Ticket {
 };
 ```
 
-You've seen this in action in the previous exercise on visibility.\
-We now need to provide one or more public **constructors**—i.e. static methods or functions that can be used
-from outside the module to create a new instance of the struct.\
-Luckily enough we already have one: `Ticket::new`, as implemented in [a previous exercise](02_validation.md).
+你在前面关于可见性 (visibility) 的练习中已经见识过这一点。\
+我们现在需要提供一个或多个公有的**构造器 (constructor)**——也就是可以从模块外部使用的、用来创建结构体实例的静态方法或函数。\
+所幸我们已经有一个：[前一个练习](02_validation.md)中实现的 `Ticket::new`。
 
-## Accessor methods
+## 访问器方法 (Accessor methods)
 
-In summary:
+总结一下：
 
-- All `Ticket` fields are private
-- We provide a public constructor, `Ticket::new`, that enforces our validation rules on creation
+- `Ticket` 的所有字段都是私有的
+- 我们提供了公有构造器 `Ticket::new`，在创建时强制执行验证规则
 
-That's a good start, but it's not enough: apart from creating a `Ticket`, we also need to interact with it.
-But how can we access the fields if they're private?
+这是个不错的开始，但还不够：除了创建 `Ticket`，我们还要与它交互。
+但如果字段是私有的，怎么访问它们呢？
 
-We need to provide **accessor methods**.\
-Accessor methods are public methods that allow you to read the value of a private field (or fields) of a struct.
+我们需要提供**访问器方法 (accessor method)**。\
+访问器方法是公有方法，允许你读取结构体一个（或多个）私有字段的值。
 
-Rust doesn't have a built-in way to generate accessor methods for you, like some other languages do.
-You have to write them yourself—they're just regular methods.
+Rust 没有像某些语言那样内建的方式来自动生成访问器方法。
+你得自己写——它们就是普通的方法。
 
-[^newtype]: Or refine their type, a technique we'll explore [later on](../05_ticket_v2/15_outro.md).
+[^newtype]: 也可以选择细化（refine）字段的类型，这是一种我们[稍后](../05_ticket_v2/15_outro.md)会探索的技术。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/05_encapsulation.md)

--- a/book/src/03_ticket_v1/06_ownership.md
+++ b/book/src/03_ticket_v1/06_ownership.md
@@ -1,7 +1,7 @@
-# Ownership
+# 所有权 (Ownership)
 
-If you solved the previous exercise using what this course has taught you so far,
-your accessor methods probably look like this:
+如果你只用本课程到目前为止所学的内容来解决前一个练习，
+你的访问器方法可能长这样：
 
 ```rust
 impl Ticket {
@@ -19,19 +19,19 @@ impl Ticket {
 }
 ```
 
-Those methods compile and are enough to get tests to pass, but in a real-world scenario they won't get you very far.
-Consider this snippet:
+这些方法能编译通过，并且足以让测试通过，但放到真实场景中就走不远了。
+看看下面这段代码：
 
 ```rust
 if ticket.status() == "To-Do" {
-    // We haven't covered the `println!` macro yet,
-    // but for now it's enough to know that it prints 
-    // a (templated) message to the console
+    // 我们还没介绍 `println!` 宏 (macro)，
+    // 但目前你只需要知道它会向控制台
+    // 打印（带模板的）信息
     println!("Your next task is: {}", ticket.title());
 }
 ```
 
-If you try to compile it, you'll get an error:
+如果你尝试编译它，会得到一个错误：
 
 ```text
 error[E0382]: use of moved value: `ticket`
@@ -55,57 +55,55 @@ note: `Ticket::status` takes ownership of the receiver `self`,
    |                       ^^^^
 ```
 
-Congrats, this is your first borrow-checker error!
+恭喜你，这是你的第一个借用检查器 (borrow-checker) 错误！
 
-## The perks of Rust's ownership system
+## Rust 所有权系统的好处 (The perks of Rust's ownership system)
 
-Rust's ownership system is designed to ensure that:
+Rust 的所有权系统旨在确保：
 
-- Data is never mutated while it's being read
-- Data is never read while it's being mutated
-- Data is never accessed after it has been destroyed
+- 数据在被读取时永远不会被修改
+- 数据在被修改时永远不会被读取
+- 数据被销毁后永远不会被访问
 
-These constraints are enforced by the **borrow checker**, a subsystem of the Rust compiler,
-often the subject of jokes and memes in the Rust community.
+这些约束由**借用检查器 (borrow checker)** 强制执行，它是 Rust 编译器的一个子系统，常常成为 Rust 社区里的笑话和梗的主角。
 
-Ownership is a key concept in Rust, and it's what makes the language unique.
-Ownership enables Rust to provide **memory safety without compromising performance**.
-All these things are true at the same time for Rust:
+所有权 (ownership) 是 Rust 中的关键概念，也是这门语言独一无二的原因。
+所有权让 Rust 能够提供**内存安全 (memory safety) 而不牺牲性能**。
+对 Rust 来说，下面这些可以同时成立：
 
-1. There is no runtime garbage collector
-2. As a developer, you rarely have to manage memory directly
-3. You can't cause dangling pointers, double frees, and other memory-related bugs
+1. 没有运行时垃圾回收器 (runtime garbage collector)
+2. 作为开发者，你很少需要直接管理内存
+3. 不会出现悬垂指针 (dangling pointer)、双重释放 (double free) 以及其他与内存相关的 bug
 
-Languages like Python, JavaScript, and Java give you 2. and 3., but not 1.\
-Language like C or C++ give you 1., but neither 2. nor 3.
+像 Python、JavaScript 和 Java 这样的语言能给你 2 和 3，但没有 1。\
+像 C 或 C++ 这样的语言给你 1，但既没有 2 也没有 3。
 
-Depending on your background, 3. might sound a bit arcane: what is a "dangling pointer"?
-What is a "double free"? Why are they dangerous?\
-Don't worry: we'll cover these concepts in more details during the rest of the course.
+根据你的背景不同，第 3 点可能听起来有点神秘：什么是"悬垂指针 (dangling pointer)"？什么是"双重释放 (double free)"？为什么它们危险？\
+别担心：在课程的剩余部分我们会更详细地讨论这些概念。
 
-For now, though, let's focus on learning how to work within Rust's ownership system.
+不过现在，我们先专注于学习如何在 Rust 的所有权系统中工作。
 
-## The owner
+## 所有者 (The owner)
 
-In Rust, each value has an **owner**, statically determined at compile-time.
-There is only one owner for each value at any given time.
+在 Rust 中，每个值都有一个**所有者 (owner)**，所有者在编译时被静态确定。
+任意时刻，每个值都只有一个所有者。
 
-## Move semantics
+## 移动语义 (Move semantics)
 
-Ownership can be transferred.
+所有权可以转移。
 
-If you own a value, for example, you can transfer ownership to another variable:
+例如，如果你拥有某个值，你可以把所有权转移给另一个变量：
 
 ```rust
-let a = "hello, world".to_string(); // <- `a` is the owner of the String
-let b = a;  // <- `b` is now the owner of the String
+let a = "hello, world".to_string(); // <- `a` 是该 String 的所有者
+let b = a;  // <- `b` 现在是该 String 的所有者
 ```
 
-Rust's ownership system is baked into the type system: each function has to declare in its signature
-_how_ it wants to interact with its arguments.
+Rust 的所有权系统是融入到类型系统中的：每个函数都必须在其签名 (signature) 中声明
+它打算如何与其参数交互。
 
-So far, all our methods and functions have **consumed** their arguments: they've taken ownership of them.
-For example:
+到目前为止，我们所有的方法和函数都**消费 (consumed)** 了它们的参数：它们获取了参数的所有权。
+例如：
 
 ```rust
 impl Ticket {
@@ -115,11 +113,10 @@ impl Ticket {
 }
 ```
 
-`Ticket::description` takes ownership of the `Ticket` instance it's called on.\
-This is known as **move semantics**: ownership of the value (`self`) is **moved** from the caller to
-the callee, and the caller can't use it anymore.
+`Ticket::description` 获取了它被调用的 `Ticket` 实例的所有权。\
+这就是所谓的**移动语义 (move semantics)**：值（`self`）的所有权从调用方**移动 (moved)** 到被调用方，调用方再也不能使用它了。
 
-That's exactly the language used by the compiler in the error message we saw earlier:
+这正是编译器在前面那条错误信息里所用的措辞：
 
 ```text
 error[E0382]: use of moved value: `ticket`
@@ -143,53 +140,52 @@ note: `Ticket::status` takes ownership of the receiver `self`,
    |                       ^^^^
 ```
 
-In particular, this is the sequence of events that unfold when we call `ticket.status()`:
+具体来说，调用 `ticket.status()` 时发生了如下事件序列：
 
-- `Ticket::status` takes ownership of the `Ticket` instance
-- `Ticket::status` extracts `status` from `self` and transfers ownership of `status` back to the caller
-- The rest of the `Ticket` instance is discarded (`title` and `description`)
+- `Ticket::status` 拿走 `Ticket` 实例的所有权
+- `Ticket::status` 从 `self` 中提取出 `status`，并把 `status` 的所有权转移回调用方
+- `Ticket` 实例的其余部分被丢弃（`title` 和 `description`）
 
-When we try to use `ticket` again via `ticket.title()`, the compiler complains: the `ticket` value is gone now,
-we no longer own it, therefore we can't use it anymore.
+接着我们尝试通过 `ticket.title()` 再次使用 `ticket` 时，编译器抱怨：`ticket` 这个值已经没了，我们不再拥有它，因此不能再使用它。
 
-To build _useful_ accessor methods we need to start working with **references**.
+要构建_有用的_访问器方法，我们需要开始使用**引用 (reference)**。
 
-## Borrowing
+## 借用 (Borrowing)
 
-It is desirable to have methods that can read the value of a variable without taking ownership of it.\
-Programming would be quite limited otherwise. In Rust, that's done via **borrowing**.
+我们希望访问器方法能读取变量的值，而不夺走它的所有权。\
+否则编程就太受限了。在 Rust 中，这通过**借用 (borrowing)** 来实现。
 
-Whenever you borrow a value, you get a **reference** to it.\
-References are tagged with their privileges[^refine]:
+每当你借用一个值时，你会得到对它的一个**引用 (reference)**。\
+引用按照其权限被打上标签[^refine]：
 
-- Immutable references (`&`) allow you to read the value, but not to mutate it
-- Mutable references (`&mut`) allow you to read and mutate the value
+- 不可变引用 (`&`)：允许你读取值，但不能修改
+- 可变引用 (`&mut`)：允许你既读取也修改值
 
-Going back to the goals of Rust's ownership system:
+回到 Rust 所有权系统的目标：
 
-- Data is never mutated while it's being read
-- Data is never read while it's being mutated
+- 数据在被读取时永远不会被修改
+- 数据在被修改时永远不会被读取
 
-To ensure these two properties, Rust has to introduce some restrictions on references:
+为了保证这两点，Rust 必须对引用引入一些限制：
 
-- You can't have a mutable reference and an immutable reference to the same value at the same time
-- You can't have more than one mutable reference to the same value at the same time
-- The owner can't mutate the value while it's being borrowed
-- You can have as many immutable references as you want, as long as there are no mutable references
+- 不能同时存在指向同一值的可变引用和不可变引用
+- 不能同时存在多个指向同一值的可变引用
+- 当一个值正在被借用时，所有者不能修改这个值
+- 只要不存在可变引用，你想要多少不可变引用都可以
 
-In a way, you can think of an immutable reference as a "read-only" lock on the value,
-while a mutable reference is like a "read-write" lock.
+某种程度上，你可以把不可变引用看作对该值的"只读 (read-only)"锁，
+而可变引用则像"读写 (read-write)"锁。
 
-All these restrictions are enforced at compile-time by the borrow checker.
+所有这些限制都由借用检查器 (borrow checker) 在编译期强制执行。
 
-### Syntax
+### 语法 (Syntax)
 
-How do you borrow a value, in practice?\
-By adding `&` or `&mut` **in front a variable**, you're borrowing its value.
-Careful though! The same symbols (`&` and `&mut`) in **front of a type** have a different meaning:
-they denote a different type, a reference to the original type.
+实际上你怎么借用一个值？\
+通过在变量**前面**加上 `&` 或 `&mut`，你就借用了它的值。
+但要注意！同样的符号（`&` 和 `&mut`）放在**类型前面**含义不同：
+它们表示一个不同的类型——对原类型的引用 (reference)。
 
-For example:
+例如：
 
 ```rust
 struct Configuration {
@@ -202,38 +198,39 @@ fn main() {
         version: 1,
         active: true,
     };
-    // `b` is a reference to the `version` field of `config`.
-    // The type of `b` is `&u32`, since it contains a reference to 
-    // a `u32` value.
-    // We create a reference by borrowing `config.version`, using 
-    // the `&` operator.
-    // Same symbol (`&`), different meaning depending on the context!
+    // `b` 是对 `config` 的 `version` 字段的引用。
+    // `b` 的类型是 `&u32`，因为它包含了对一个
+    // `u32` 值的引用。
+    // 我们用 `&` 运算符借用 `config.version`，
+    // 创建了一个引用。
+    // 同样的符号 (`&`)，根据上下文含义不同！
     let b: &u32 = &config.version;
-    //     ^ The type annotation is not necessary, 
-    //       it's just there to clarify what's going on
+    //     ^ 类型注解 (type annotation) 不是必需的，
+    //       这里写出来只是为了说明发生了什么
 }
 ```
 
-The same concept applies to function arguments and return types:
+同样的概念也适用于函数参数和返回类型：
 
 ```rust
-// `f` takes a mutable reference to a `u32` as an argument, 
-// bound to the name `number`
+// `f` 接受一个对 `u32` 的可变引用作为参数，
+// 绑定到名字 `number`
 fn f(number: &mut u32) -> &u32 {
     // [...]
 }
 ```
 
-## Breathe in, breathe out
+## 深呼吸 (Breathe in, breathe out)
 
-Rust's ownership system can be a bit overwhelming at first.\
-But don't worry: it'll become second nature with practice.\
-And you're going to get a lot of practice over the rest of this chapter, as well as the rest of the course!
-We'll revisit each concept multiple times to make sure you get familiar with them
-and truly understand how they work.
+Rust 的所有权系统初看可能有点压倒性。\
+但别担心：随着练习的增多，它会变成你的第二天性。\
+本章剩余部分以及整个课程都会让你练个够！
+我们会反复回顾每个概念，确保你对它们足够熟悉、真正理解它们的工作原理。
 
-Towards the end of this chapter we'll explain _why_ Rust's ownership system is designed the way it is.
-For the time being, focus on understanding the _how_. Take each compiler error as a learning opportunity!
+到本章末尾，我们会解释 Rust 的所有权系统_为什么_要这样设计。
+此刻，先专注于理解_怎么用_。把每条编译器错误都当作一次学习机会！
 
-[^refine]: This is a great mental model to start out, but it doesn't capture the _full_ picture.
-We'll refine our understanding of references [later in the course](../07_threads/06_interior_mutability.md).
+[^refine]: 这是个不错的入门心智模型，但它没有捕捉到_完整_的图景。
+我们在课程[后面](../07_threads/06_interior_mutability.md)会进一步细化对引用 (reference) 的理解。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/06_ownership.md)

--- a/book/src/03_ticket_v1/07_setters.md
+++ b/book/src/03_ticket_v1/07_setters.md
@@ -1,6 +1,6 @@
-# Mutable references
+# 可变引用 (Mutable references)
 
-Your accessor methods should look like this now:
+到现在你的访问器方法应该长这样：
 
 ```rust
 impl Ticket {
@@ -18,36 +18,35 @@ impl Ticket {
 }
 ```
 
-A sprinkle of `&` here and there did the trick!\
-We now have a way to access the fields of a `Ticket` instance without consuming it in the process.
-Let's see how we can enhance our `Ticket` struct with **setter methods** next.
+这里那里撒上几个 `&` 就搞定了！\
+我们现在有了一种访问 `Ticket` 实例字段而又不消耗它的方式。
+接下来看看怎么用**setter 方法 (setter method)** 来增强我们的 `Ticket` 结构体。
 
-## Setters
+## Setter
 
-Setter methods allow users to change the values of `Ticket`'s private fields while making sure that its invariants
-are respected (i.e. you can't set a `Ticket`'s title to an empty string).
+Setter 方法允许用户修改 `Ticket` 私有字段的值，同时保证不变量 (invariant) 得到尊重（也就是说，你不能把 `Ticket` 的标题设为空字符串）。
 
-There are two common ways to implement setters in Rust:
+在 Rust 中实现 setter 有两种常见方式：
 
-- Taking `self` as input.
-- Taking `&mut self` as input.
+- 以 `self` 作为输入。
+- 以 `&mut self` 作为输入。
 
-### Taking `self` as input
+### 以 `self` 作为输入 (Taking `self` as input)
 
-The first approach looks like this:
+第一种方式像这样：
 
 ```rust
 impl Ticket {
     pub fn set_title(mut self, new_title: String) -> Self {
-        // Validate the new title [...]
+        // 验证新标题 [...]
         self.title = new_title;
         self
     }
 }
 ```
 
-It takes ownership of `self`, changes the title, and returns the modified `Ticket` instance.\
-This is how you'd use it:
+它拿走 `self` 的所有权，修改标题，再把修改后的 `Ticket` 实例返回。\
+你会这样使用它：
 
 ```rust
 let ticket = Ticket::new(
@@ -58,12 +57,10 @@ let ticket = Ticket::new(
 let ticket = ticket.set_title("New title".into());
 ```
 
-Since `set_title` takes ownership of `self` (i.e. it **consumes it**), we need to reassign the result to a variable.
-In the example above we take advantage of **variable shadowing** to reuse the same variable name: when
-you declare a new variable with the same name as an existing one, the new variable **shadows** the old one. This
-is a common pattern in Rust code.
+由于 `set_title` 拿走了 `self` 的所有权（即**消费 (consumes)** 它），我们需要把结果重新赋给一个变量。
+上面的例子利用了**变量遮蔽 (variable shadowing)** 来重用同一个变量名：当你用一个已存在的名字声明一个新变量时，新变量会**遮蔽 (shadow)** 旧变量。这是 Rust 代码中常见的模式。
 
-`self`-setters work quite nicely when you need to change multiple fields at once: you can chain multiple calls together!
+`self` 风格的 setter 在你需要一次性修改多个字段时表现得很好：你可以把多个调用串起来！
 
 ```rust
 let ticket = ticket
@@ -72,24 +69,24 @@ let ticket = ticket
     .set_status("In Progress".into());
 ```
 
-### Taking `&mut self` as input
+### 以 `&mut self` 作为输入 (Taking `&mut self` as input)
 
-The second approach to setters, using `&mut self`, looks like this instead:
+第二种 setter 方式使用 `&mut self`，看起来像这样：
 
 ```rust
 impl Ticket {
     pub fn set_title(&mut self, new_title: String) {
-        // Validate the new title [...]
+        // 验证新标题 [...]
         
         self.title = new_title;
     }
 }
 ```
 
-This time the method takes a mutable reference to `self` as input, changes the title, and that's it.
-Nothing is returned.
+这次方法接受的是对 `self` 的可变引用，修改标题，仅此而已。
+什么也不返回。
 
-You'd use it like this:
+你会这样使用它：
 
 ```rust
 let mut ticket = Ticket::new(
@@ -99,18 +96,20 @@ let mut ticket = Ticket::new(
 );
 ticket.set_title("New title".into());
 
-// Use the modified ticket
+// 使用修改后的 ticket
 ```
 
-Ownership stays with the caller, so the original `ticket` variable is still valid. We don't need to reassign the result.
-We need to mark `ticket` as mutable though, because we're taking a mutable reference to it.
+所有权仍然在调用方手里，因此原来的 `ticket` 变量依旧有效。我们不需要把结果重新赋值。
+不过我们要把 `ticket` 标记为 `mut`（可变），因为我们对它取了可变引用。
 
-`&mut`-setters have a downside: you can't chain multiple calls together.
-Since they don't return the modified `Ticket` instance, you can't call another setter on the result of the first one.
-You have to call each setter separately:
+`&mut` 风格的 setter 有个缺点：你不能把多个调用串起来。
+因为它们不返回修改后的 `Ticket` 实例，所以你不能在第一个调用的结果上再调用另一个 setter。
+你必须分别调用每个 setter：
 
 ```rust
 ticket.set_title("New title".into());
 ticket.set_description("New description".into());
 ticket.set_status("In Progress".into());
 ```
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/07_setters.md)

--- a/book/src/03_ticket_v1/08_stack.md
+++ b/book/src/03_ticket_v1/08_stack.md
@@ -1,29 +1,27 @@
-# Memory layout
+# 内存布局 (Memory layout)
 
-We've looked at ownership and references from an operational point of view—what you can and can't do with them.
-Now it's a good time to take a look under the hood: let's talk about **memory**.
+我们已经从操作层面看过了所有权 (ownership) 和引用 (reference)——能做什么、不能做什么。
+现在是时候掀开盖子看看：聊聊**内存 (memory)** 吧。
 
-## Stack and heap
+## 栈与堆 (Stack and heap)
 
-When discussing memory, you'll often hear people talk about the **stack** and the **heap**.\
-These are two different memory regions used by programs to store data.
+谈到内存时，你常常会听人提起**栈 (stack)** 和**堆 (heap)**。\
+它们是程序用来存储数据的两种不同的内存区域。
 
-Let's start with the stack.
+我们先从栈讲起。
 
-## Stack
+## 栈 (Stack)
 
-The **stack** is a **LIFO** (Last In, First Out) data structure.\
-When you call a function, a new **stack frame** is added on top of the stack. That stack frame stores
-the function's arguments, local variables and a few "bookkeeping" values.\
-When the function returns, the stack frame is popped off the stack[^stack-overflow].
+**栈 (stack)** 是一种 **LIFO**（Last In, First Out，后进先出）数据结构。\
+当你调用一个函数时，一个新的**栈帧 (stack frame)** 会被压到栈顶。这个栈帧用于存储函数的参数、局部变量以及一些"簿记 (bookkeeping)"值。\
+当函数返回时，对应的栈帧会从栈上弹出[^stack-overflow]。
 
 ```text
 +-----------------+
 | frame for func1 |
 +-----------------+
         |
-        | func2 is 
-        | called
+        | 调用 func2
         v
 +-----------------+
 | frame for func2 |
@@ -31,42 +29,41 @@ When the function returns, the stack frame is popped off the stack[^stack-overfl
 | frame for func1 |
 +-----------------+
         |
-        | func2  
-        | returns
+        | func2 返回
         v
 +-----------------+
 | frame for func1 |
 +-----------------+
 ```
 
-From an operational point of view, stack allocation/de-allocation is **very fast**.\
-We are always pushing and popping data from the top of the stack, so we don't need to search for free memory.
-We also don't have to worry about fragmentation: the stack is a single contiguous block of memory.
+从操作层面看，栈上的分配/释放**非常快**。\
+我们总是从栈顶压入和弹出数据，因此不需要去搜索可用内存。
+我们也不必担心碎片 (fragmentation)：栈是一整块连续 (contiguous) 的内存。
 
 ### Rust
 
-Rust will often allocate data on the stack.\
-You have a `u32` input argument in a function? Those 32 bits will be on the stack.\
-You define a local variable of type `i64`? Those 64 bits will be on the stack.\
-It all works quite nicely because the size of those integers is known at compile time, therefore
-the compiled program knows how much space it needs to reserve on the stack for them.
+Rust 经常把数据放在栈上。\
+你的函数有一个 `u32` 类型的输入参数？那 32 位会放在栈上。\
+你定义了一个 `i64` 类型的局部变量？那 64 位也会放在栈上。\
+这一切运转良好，是因为这些整数的大小在编译期就已知，因此编译后的程序知道为它们在栈上保留多少空间。
 
 ### `std::mem::size_of`
 
-You can verify how much space a type would take on the stack
-using the [`std::mem::size_of`](https://doc.rust-lang.org/std/mem/fn.size_of.html) function.
+你可以使用 [`std::mem::size_of`](https://doc.rust-lang.org/std/mem/fn.size_of.html) 函数来查看某个类型在栈上会占用多少空间。
 
-For a `u8`, for example:
+例如对 `u8`：
 
 ```rust
-// We'll explain this funny-looking syntax (`::<u8>`) later on.
-// Ignore it for now.
+// 这个奇怪的语法 (`::<u8>`) 我们之后再讲。
+// 现在先忽略它。
 assert_eq!(std::mem::size_of::<u8>(), 1);
 ```
 
-1 makes sense, because a `u8` is 8 bits long, or 1 byte.
+结果是 1，这很合理，因为 `u8` 是 8 位长，也就是 1 字节。
 
-[^stack-overflow]: If you have nested function calls, each function pushes its data onto the stack when it's called but
-it doesn't pop it off until the innermost function returns.
-If you have too many nested function calls, you can run out of stack space—the stack is not infinite!
-That's called a [**stack overflow**](https://en.wikipedia.org/wiki/Stack_overflow).
+[^stack-overflow]: 如果你有嵌套的函数调用，每个函数被调用时都把它的数据压到栈上，
+但要等到最内层的函数返回时才会弹出。
+如果嵌套调用太深，你可能会用尽栈空间——栈不是无限的！
+这就叫 [**栈溢出 (stack overflow)**](https://en.wikipedia.org/wiki/Stack_overflow)。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/08_stack.md)

--- a/book/src/03_ticket_v1/09_heap.md
+++ b/book/src/03_ticket_v1/09_heap.md
@@ -1,20 +1,19 @@
-# Heap
+# 堆 (Heap)
 
-The stack is great, but it can't solve all our problems. What about data whose size is not known at compile time?
-Collections, strings, and other dynamically-sized data cannot be (entirely) stack-allocated.
-That's where the **heap** comes in.
+栈很棒，但它不能解决我们所有的问题。那些大小在编译期未知的数据怎么办？
+集合 (collection)、字符串 (string) 以及其他动态尺寸 (dynamically-sized) 的数据无法（完整地）放到栈上。
+这就轮到**堆 (heap)** 登场了。
 
-## Heap allocations
+## 堆分配 (Heap allocations)
 
-You can visualize the heap as a big chunk of memory—a huge array, if you will.\
-Whenever you need to store data on the heap, you ask a special program, the **allocator**, to reserve for you
-a subset of the heap. We call this interaction (and the memory you reserved) a **heap allocation**.
-If the allocation succeeds, the allocator will give you a **pointer** to the start of the reserved block.
+你可以把堆想象成一大块内存——如果愿意的话，可以把它当成一个巨大的数组。\
+每当你需要在堆上存储数据时，你向一个特殊的程序——**分配器 (allocator)**——请求为你预留堆中的一部分。我们把这种交互（以及你预留的那块内存）称作一次**堆分配 (heap allocation)**。
+如果分配成功，分配器会给你一个指向所预留区块起始位置的**指针 (pointer)**。
 
-## No automatic de-allocation
+## 没有自动释放 (No automatic de-allocation)
 
-The heap is structured quite differently from the stack.\
-Heap allocations are not contiguous, they can be located anywhere inside the heap.
+堆的结构与栈相当不同。\
+堆分配不是连续的，它们可以位于堆中的任意位置。
 
 ```
 +---+---+---+---+---+---+-...-+-...-+---+---+---+---+---+---+---+
@@ -22,35 +21,33 @@ Heap allocations are not contiguous, they can be located anywhere inside the hea
 +---+---+---+---+---+---+ ... + ... +---+---+---+---+---+---+---+
 ```
 
-It's the allocator's job to keep track of which parts of the heap are in use and which are free.
-The allocator won't automatically free the memory you allocated, though: you need to be deliberate about it,
-calling the allocator again to **free** the memory you no longer need.
+哪些区域在使用、哪些是空闲的，由分配器来跟踪。
+不过分配器不会自动释放你分配的内存：你需要主动行事，再次调用分配器来**释放 (free)** 你不再需要的内存。
 
-## Performance
+## 性能 (Performance)
 
-The heap's flexibility comes at a cost: heap allocations are **slower** than stack allocations.
-There's a lot more bookkeeping involved!\
-If you read articles about performance optimization you'll often be advised to minimize heap allocations
-and prefer stack-allocated data whenever possible.
+堆的灵活性是有代价的：堆分配比栈分配**更慢**。
+其中涉及大量的簿记！\
+如果你读过性能优化方面的文章，常会看到这样的建议：尽量减少堆分配，能用栈分配的就用栈。
 
-## `String`'s memory layout
+## `String` 的内存布局 (`String`'s memory layout)
 
-When you create a local variable of type `String`,
-Rust is forced to allocate on the heap[^empty]: it doesn't know in advance how much text you're going to put in it,
-so it can't reserve the right amount of space on the stack.\
-But a `String` is not _entirely_ heap-allocated, it also keeps some data on the stack. In particular:
+当你创建一个 `String` 类型的局部变量时，
+Rust 不得不在堆上分配[^empty]：它无法事先知道你要往里塞多少文本，
+所以无法在栈上提前预留合适的空间。\
+但 `String` 并不是_完全_位于堆上，它在栈上也保留了一些数据。具体来说：
 
-- The **pointer** to the heap region you reserved.
-- The **length** of the string, i.e. how many bytes are in the string.
-- The **capacity** of the string, i.e. how many bytes have been reserved on the heap.
+- 指向你预留的堆区域的**指针 (pointer)**。
+- 字符串的**长度 (length)**，即字符串当前包含的字节数。
+- 字符串的**容量 (capacity)**，即在堆上预留了多少字节。
 
-Let's look at an example to understand this better:
+我们看个例子来更好理解：
 
 ```rust
 let mut s = String::with_capacity(5);
 ```
 
-If you run this code, memory will be laid out like this:
+如果你运行这段代码，内存布局会是这样：
 
 ```
       +---------+--------+----------+
@@ -65,14 +62,11 @@ Heap:  | ? | ? | ? | ? | ? |
        +---+---+---+---+---+
 ```
 
-We asked for a `String` that can hold up to 5 bytes of text.\
-`String::with_capacity` goes to the allocator and asks for 5 bytes of heap memory. The allocator returns
-a pointer to the start of that memory block.\
-The `String` is empty, though. On the stack, we keep track of this information by distinguishing between
-the length and the capacity: this `String` can hold up to 5 bytes, but it currently holds 0 bytes of
-actual text.
+我们请求了一个最多能装 5 字节文本的 `String`。\
+`String::with_capacity` 向分配器请求 5 字节的堆内存。分配器返回一个指向那块内存起始位置的指针。\
+不过此时 `String` 是空的。在栈上，我们通过区分长度 (length) 和容量 (capacity) 来记录这一信息：这个 `String` 最多可装 5 字节，但当前只装了 0 字节实际文本。
 
-If you push some text into the `String`, the situation will change:
+如果你往 `String` 里塞一些文本，情况就变了：
 
 ```rust
 s.push_str("Hey");
@@ -91,52 +85,49 @@ Heap:  | H | e | y | ? | ? |
        +---+---+---+---+---+
 ```
 
-`s` now holds 3 bytes of text. Its length is updated to 3, but capacity remains 5.
-Three of the five bytes on the heap are used to store the characters `H`, `e`, and `y`.
+`s` 现在装了 3 字节的文本。它的长度更新为 3，但容量仍是 5。
+堆上 5 个字节中有 3 个被用来存储字符 `H`、`e` 和 `y`。
 
 ### `usize`
 
-How much space do we need to store pointer, length and capacity on the stack?\
-It depends on the **architecture** of the machine you're running on.
+我们要在栈上存指针、长度和容量，需要多大空间？\
+这取决于你运行机器的**架构 (architecture)**。
 
-Every memory location on your machine has an [**address**](https://en.wikipedia.org/wiki/Memory_address), commonly
-represented as an unsigned integer.
-Depending on the maximum size of the address space (i.e. how much memory your machine can address),
-this integer can have a different size. Most modern machines use either a 32-bit or a 64-bit address space.
+机器上的每个内存位置都有一个[**地址 (address)**](https://en.wikipedia.org/wiki/Memory_address)，通常表示为一个无符号整数。
+根据地址空间的最大大小（即你的机器能寻址多少内存）不同，
+这个整数可能有不同的大小。大多数现代机器使用 32 位或 64 位的地址空间。
 
-Rust abstracts away these architecture-specific details by providing the `usize` type:
-an unsigned integer that's as big as the number of bytes needed to address memory on your machine.
-On a 32-bit machine, `usize` is equivalent to `u32`. On a 64-bit machine, it matches `u64`.
+Rust 通过提供 `usize` 类型来抽象掉这些与架构相关的细节：
+一个无符号整数，其大小恰好等于在你机器上寻址内存所需的字节数。
+在 32 位机器上，`usize` 等价于 `u32`；在 64 位机器上，对应 `u64`。
 
-Capacity, length and pointers are all represented as `usize`s in Rust[^equivalence].
+容量、长度和指针在 Rust 中都用 `usize` 表示[^equivalence]。
 
-### No `std::mem::size_of` for the heap
+### 堆上没有 `std::mem::size_of` (No `std::mem::size_of` for the heap)
 
-`std::mem::size_of` returns the amount of space a type would take on the stack,
-which is also known as the **size of the type**.
+`std::mem::size_of` 返回某个类型在栈上会占用多少空间，
+也称为**类型的大小 (size of the type)**。
 
-> What about the memory buffer that `String` is managing on the heap? Isn't that
-> part of the size of `String`?
+> 那么 `String` 在堆上管理的内存缓冲区呢？它不算 `String` 大小的一部分吗？
 
-No!\
-That heap allocation is a **resource** that `String` is managing.
-It's not considered to be part of the `String` type by the compiler.
+不算！\
+那块堆分配是 `String` 所**管理的资源**。
+编译器并不把它看作 `String` 类型的一部分。
 
-`std::mem::size_of` doesn't know (or care) about additional heap-allocated data
-that a type might manage or refer to via pointers, as is the case with `String`,
-therefore it doesn't track its size.
+`std::mem::size_of` 不知道（也不在乎）某个类型可能管理或通过指针引用的额外堆内存——`String` 就属于这种情况——
+因此它不会跟踪这部分大小。
 
-Unfortunately there is no equivalent of `std::mem::size_of` to measure the amount of
-heap memory that a certain value is allocating at runtime. Some types might
-provide methods to inspect their heap usage (e.g. `String`'s `capacity` method),
-but there is no general-purpose "API" to retrieve runtime heap usage in Rust.\
-You can, however, use a memory profiler tool (e.g. [DHAT](https://valgrind.org/docs/manual/dh-manual.html)
-or [a custom allocator](https://docs.rs/dhat/latest/dhat/)) to inspect the heap usage of your program.
+不幸的是，目前没有等价于 `std::mem::size_of` 的工具来在运行时测量某个值正在分配多少堆内存。
+某些类型可能提供方法来查看它们的堆使用情况（例如 `String` 的 `capacity` 方法），
+但 Rust 没有通用的"API"来在运行时获取堆使用情况。\
+不过你可以用内存分析工具（例如 [DHAT](https://valgrind.org/docs/manual/dh-manual.html)
+或[自定义分配器 (custom allocator)](https://docs.rs/dhat/latest/dhat/)）来检查程序的堆使用情况。
 
-[^empty]: `std` doesn't allocate if you create an **empty** `String` (i.e. `String::new()`).
-Heap memory will be reserved when you push data into it for the first time.
+[^empty]: 如果你创建一个**空** `String`（即 `String::new()`），`std` 不会进行堆分配。
+当你第一次往里塞数据时，才会预留堆内存。
 
-[^equivalence]: The size of a pointer depends on the operating system too.
-In certain environments, a pointer is **larger** than a memory address (e.g. [CHERI](https://web.archive.org/web/20240517051950/https://blog.acolyer.org/2019/05/28/cheri-abi/)).
-Rust makes the simplifying assumption that pointers are the same size as memory addresses,
-which is true for most modern systems you're likely to encounter.
+[^equivalence]: 指针的大小还取决于操作系统。
+在某些环境下，指针**比**内存地址更大（例如 [CHERI](https://web.archive.org/web/20240517051950/https://blog.acolyer.org/2019/05/28/cheri-abi/)）。
+Rust 做了一个简化假设——指针和内存地址同样大——这对你大多数现代系统来说是成立的。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/09_heap.md)

--- a/book/src/03_ticket_v1/10_references_in_memory.md
+++ b/book/src/03_ticket_v1/10_references_in_memory.md
@@ -1,26 +1,26 @@
-# References
+# 引用 (References)
 
-What about references, like `&String` or `&mut String`? How are they represented in memory?
+那么 `&String` 或 `&mut String` 这样的引用呢？它们在内存中是如何表示的？
 
-Most references[^fat] in Rust are represented, in memory, as a pointer to a memory location.\
-It follows that their size is the same as the size of a pointer, a `usize`.
+Rust 中大多数引用[^fat]在内存中都表示为指向一个内存位置的指针。\
+因此它们的大小与指针大小相同，也就是一个 `usize`。
 
-You can verify this using `std::mem::size_of`:
+你可以使用 `std::mem::size_of` 来验证：
 
 ```rust
 assert_eq!(std::mem::size_of::<&String>(), 8);
 assert_eq!(std::mem::size_of::<&mut String>(), 8);
 ```
 
-A `&String`, in particular, is a pointer to the memory location where the `String`'s metadata is stored.\
-If you run this snippet:
+具体来说，`&String` 是一个指向存储 `String` 元数据 (metadata) 的内存位置的指针。\
+如果你运行下面这段代码：
 
 ```rust
 let s = String::from("Hey");
 let r = &s;
 ```
 
-you'll get something like this in memory:
+内存中你会看到类似这样的布局：
 
 ```
            --------------------------------------
@@ -37,14 +37,15 @@ Heap   | H | e | y | ? | ? |
        +---+---+---+---+---+
 ```
 
-It's a pointer to a pointer to the heap-allocated data, if you will.
-The same goes for `&mut String`.
+如果你愿意这么想：它是一个指向"指向堆上数据的指针"的指针。
+`&mut String` 也是一样。
 
-## Not all pointers point to the heap
+## 不是所有指针都指向堆 (Not all pointers point to the heap)
 
-The example above should clarify one thing: not all pointers point to the heap.\
-They just point to a memory location, which _may_ be on the heap, but doesn't have to be.
+上面的例子应该能澄清一件事：并不是所有指针都指向堆。\
+它们仅仅指向某个内存位置——_可能_在堆上，但不一定。
 
-[^fat]: [Later in the course](../04_traits/06_str_slice.md) we'll talk about **fat pointers**,
-i.e. pointers with additional metadata. As the name implies, they are larger than
-the pointers we discussed in this chapter, also known as **thin pointers**.
+[^fat]: 在课程的[后面](../04_traits/06_str_slice.md)我们会讨论**胖指针 (fat pointer)**，
+也就是带额外元数据的指针。顾名思义，它们比本章讨论的指针更大——后者也叫**瘦指针 (thin pointer)**。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/10_references_in_memory.md)

--- a/book/src/03_ticket_v1/11_destructor.md
+++ b/book/src/03_ticket_v1/11_destructor.md
@@ -1,53 +1,52 @@
-# Destructors
+# 析构函数 (Destructors)
 
-When introducing the heap, we mentioned that you're responsible for freeing the memory you allocate.\
-When introducing the borrow-checker, we also stated that you rarely have to manage memory directly in Rust.
+引入堆 (heap) 时，我们提到过：你分配的内存需要由你自己负责释放。\
+引入借用检查器 (borrow-checker) 时，我们又说在 Rust 里你很少需要直接管理内存。
 
-These two statements might seem contradictory at first.
-Let's see how they fit together by introducing **scopes** and **destructors**.
+这两条乍一看像是矛盾的。
+让我们通过引入**作用域 (scope)** 和**析构函数 (destructor)** 来看看它们如何能合得拢。
 
-## Scopes
+## 作用域 (Scopes)
 
-The **scope** of a variable is the region of Rust code where that variable is valid, or **alive**.
+变量的**作用域 (scope)** 是 Rust 代码中该变量有效（即**存活 (alive)**）的区域。
 
-The scope of a variable starts with its declaration.
-It ends when one of the following happens:
+变量的作用域从它声明开始。
+作用域结束于以下任意一种情况：
 
-1. the block (i.e. the code between `{}`) where the variable was declared ends
+1. 变量声明所在的代码块（即 `{}` 之间的代码）结束
    ```rust
    fn main() {
-      // `x` is not yet in scope here
+      // `x` 这里还不在作用域中
       let y = "Hello".to_string();
-      let x = "World".to_string(); // <-- x's scope starts here...
+      let x = "World".to_string(); // <-- x 的作用域从这里开始……
       let h = "!".to_string(); //   |
-   } //  <-------------- ...and ends here
+   } //  <-------------- ……到这里结束
    ```
-2. ownership of the variable is transferred to someone else (e.g. a function or another variable)
+2. 变量的所有权被转移给了别人（例如某个函数或另一个变量）
    ```rust
    fn compute(t: String) {
-      // Do something [...]
+      // 做点事情 [...]
    }
 
    fn main() {
-       let s = "Hello".to_string(); // <-- s's scope starts here...
+       let s = "Hello".to_string(); // <-- s 的作用域从这里开始……
                    //                    | 
-       compute(s); // <------------------- ..and ends here
-                   //   because `s` is moved into `compute`
+       compute(s); // <------------------- ……到这里结束
+                   //   因为 `s` 被移动 (moved) 到了 `compute` 中
    }
    ```
 
-## Destructors
+## 析构函数 (Destructors)
 
-When the owner of a value goes out of scope, Rust invokes its **destructor**.\
-The destructor tries to clean up the resources used by that value—in particular, whatever memory it allocated.
+当一个值的所有者离开作用域时，Rust 会调用它的**析构函数 (destructor)**。\
+析构函数会尝试清理该值所使用的资源——尤其是它分配过的内存。
 
-You can manually invoke the destructor of a value by passing it to `std::mem::drop`.\
-That's why you'll often hear Rust developers saying "that value has been **dropped**" as a way to state that a value
-has gone out of scope and its destructor has been invoked.
+你可以通过把值传给 `std::mem::drop` 来手动调用它的析构函数。\
+这就是为什么你常听到 Rust 开发者说"那个值已经被 **drop（丢弃）了**"——表示该值离开了作用域、其析构函数已被调用。
 
-### Visualizing drop points
+### 可视化 drop 的位置 (Visualizing drop points)
 
-We can insert explicit calls to `drop` to "spell out" what the compiler does for us. Going back to the previous example:
+我们可以通过插入显式的 `drop` 调用来"明示"编译器替我们做了什么。回到前面的例子：
 
 ```rust
 fn main() {
@@ -57,25 +56,25 @@ fn main() {
 }
 ```
 
-It's equivalent to:
+它等价于：
 
 ```rust
 fn main() {
    let y = "Hello".to_string();
    let x = "World".to_string();
    let h = "!".to_string();
-   // Variables are dropped in reverse order of declaration
+   // 变量按声明的反向顺序被丢弃 (drop)
    drop(h);
    drop(x);
    drop(y);
 }
 ```
 
-Let's look at the second example instead, where `s`'s ownership is transferred to `compute`:
+再看第二个例子，`s` 的所有权被转移给了 `compute`：
 
 ```rust
 fn compute(s: String) {
-   // Do something [...]
+   // 做点事情 [...]
 }
 
 fn main() {
@@ -84,14 +83,13 @@ fn main() {
 }
 ```
 
-It's equivalent to this:
+它等价于：
 
 ```rust
 fn compute(t: String) {
-    // Do something [...]
-    drop(t); // <-- Assuming `t` wasn't dropped or moved 
-             //     before this point, the compiler will call 
-             //     `drop` here, when it goes out of scope
+    // 做点事情 [...]
+    drop(t); // <-- 假设 `t` 在此之前没有被 drop 或被移动 (move)，
+             //     编译器会在这里——它离开作用域时——调用 `drop`
 }
 
 fn main() {
@@ -100,16 +98,14 @@ fn main() {
 }
 ```
 
-Notice the difference: even though `s` is no longer valid after `compute` is called in `main`, there is no `drop(s)`
-in `main`.
-When you transfer ownership of a value to a function, you're also **transferring the responsibility of cleaning it up**.
+注意区别：尽管 `compute` 调用之后 `s` 在 `main` 中已经无效，但 `main` 里并没有 `drop(s)`。
+当你把一个值的所有权转移给一个函数时，你也**把清理它的责任一并转移过去了**。
 
-This ensures that the destructor for a value is called **at most[^leak] once**, preventing
-[double free bugs](https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory) by design.
+这能确保某个值的析构函数**最多[^leak]被调用一次**，从设计上避免了 [双重释放 bug (double free bugs)](https://owasp.org/www-community/vulnerabilities/Doubly_freeing_memory)。
 
-### Use after drop
+### 释放后再使用 (Use after drop)
 
-What happens if you try to use a value after it's been dropped?
+如果你试图在一个值被 drop 后还使用它，会发生什么？
 
 ```rust
 let x = "Hello".to_string();
@@ -117,7 +113,7 @@ drop(x);
 println!("{}", x);
 ```
 
-If you try to compile this code, you'll get an error:
+如果你尝试编译这段代码，会得到一个错误：
 
 ```rust
 error[E0382]: use of moved value: `x`
@@ -129,13 +125,13 @@ error[E0382]: use of moved value: `x`
   |                    ^ value used here after move
 ```
 
-Drop **consumes** the value it's called on, meaning that the value is no longer valid after the call.\
-The compiler will therefore prevent you from using it, avoiding [use-after-free bugs](https://owasp.org/www-community/vulnerabilities/Using_freed_memory).
+`drop` **消费 (consumes)** 了它被调用的那个值，意味着调用之后该值就不再有效。\
+因此编译器会阻止你使用它，从而避免了 [释放后使用 bug (use-after-free bugs)](https://owasp.org/www-community/vulnerabilities/Using_freed_memory)。
 
-### Dropping references
+### 丢弃引用 (Dropping references)
 
-What if a variable contains a reference?\
-For example:
+如果变量保存的是一个引用呢？\
+例如：
 
 ```rust
 let x = 42i32;
@@ -143,8 +139,8 @@ let y = &x;
 drop(y);
 ```
 
-When you call `drop(y)`... nothing happens.\
-If you actually try to compile this code, you'll get a warning:
+当你调用 `drop(y)` 时……什么也不会发生。\
+如果你真的尝试编译这段代码，会得到一条警告：
 
 ```text
 warning: calls to `std::mem::drop` with a reference 
@@ -158,12 +154,13 @@ warning: calls to `std::mem::drop` with a reference
   |
 ```
 
-It goes back to what we said earlier: we only want to call the destructor once.\
-You can have multiple references to the same value—if we called the destructor for the value they point at
-when one of them goes out of scope, what would happen to the others?
-They would refer to a memory location that's no longer valid: a so-called [**dangling pointer**](https://en.wikipedia.org/wiki/Dangling_pointer),
-a close relative of [**use-after-free bugs**](https://owasp.org/www-community/vulnerabilities/Using_freed_memory).
-Rust's ownership system rules out these kinds of bugs by design.
+这回到我们前面说的：我们只想让析构函数被调用一次。\
+你可以同时持有多个指向同一个值的引用——如果其中一个引用离开作用域时就调用值的析构函数，那其他引用怎么办？
+它们将指向一个不再有效的内存位置：所谓的[**悬垂指针 (dangling pointer)**](https://en.wikipedia.org/wiki/Dangling_pointer)，
+是 [**释放后使用 bug (use-after-free bug)**](https://owasp.org/www-community/vulnerabilities/Using_freed_memory) 的近亲。
+Rust 的所有权系统从设计上排除了这一类 bug。
 
-[^leak]: Rust doesn't guarantee that destructors will run. They won't, for example, if
-you explicitly choose to [leak memory](../07_threads/03_leak.md).
+[^leak]: Rust 不保证析构函数一定会运行。例如，如果你显式选择[泄漏内存 (leak memory)](../07_threads/03_leak.md)，
+它们就不会运行。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/11_destructor.md)

--- a/book/src/03_ticket_v1/12_outro.md
+++ b/book/src/03_ticket_v1/12_outro.md
@@ -1,5 +1,7 @@
-# Wrapping up
+# 总结 (Wrapping up)
 
-We've covered a lot of foundational Rust concepts in this chapter.\
-Before moving on, let's go through one last exercise to consolidate what we've learned.
-You'll have minimal guidance this time—just the exercise description and the tests to guide you.
+本章我们覆盖了相当多 Rust 的基础概念。\
+继续向前之前，让我们再做最后一个练习来巩固所学。
+这次你只会得到很少的指引——只有练习描述和测试可供参考。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/03_ticket_v1/12_outro.md)


### PR DESCRIPTION
## Summary

进度：14/100 → 27/100（+13）

### 1. 第 3 章全章翻译（commit `0ae06de`）

| 文件 | 主题 |
|---|---|
| 00_intro | 工单建模引入 |
| 01_struct | 结构体、字段、方法、self/静态方法 |
| 02_validation | 字段验证引入 |
| 03_modules | 模块系统、内联模块、模块树、use 语句 |
| 04_visibility | 可见性修饰符 (pub / pub(crate) / pub(super)) |
| 05_encapsulation | 封装与访问器方法 |
| 06_ownership | 所有权、借用检查器、引用、移动语义 |
| 07_setters | 可变引用、self / &mut self 风格的 setter |
| 08_stack | 栈、栈帧、std::mem::size_of |
| 09_heap | 堆、分配器、String 内存布局、usize |
| 10_references_in_memory | 引用的内存表示、瘦/胖指针 |
| 11_destructor | 作用域、析构函数、drop、悬垂指针 |
| 12_outro | 章节总结 |

### 2. 添加 `/translate-next` slash command（commit `0bab539`）

`.claude/commands/translate-next.md`，配合 `/loop` 实现章节翻译半自动化。详见命令本身的注释。

### 同步更新

- `README.md` checklist 第 3 章全勾
- `00_welcome.md` 进度数 14% → 27%

## 翻译规范

- 专业术语首次出现 `中文 (english term)` 标注
- 标题格式 `# 中文 (English Title)`，多部分章节 `# 中文，第 N 部分 (Title, part N)`
- 代码块、错误信息、`println!` 字符串中的代码标识符保持原样
- 内部相对链接保持原样
- 末尾追加 `> 原文链接：[英文原文](...)`

## Test plan

- [ ] mdbook 渲染检查 13 篇 + slash command 文件
- [ ] 内部链接核对（如 `../02_basic_calculator/09_saturating.md`、`../05_ticket_v2/15_outro.md`、`../04_traits/06_str_slice.md`、`../07_threads/03_leak.md`、`../07_threads/06_interior_mutability.md`）
- [ ] 术语一致性
- [ ] Cloudflare Pages 分支预览

https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA)_