### PR TITLE
翻译: 第 6 章 工单管理 Ticket Management（17 篇）

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,23 +126,23 @@
 - [x] ✅ 05_ticket_v2/15_outro.md
 
 ### 第6章：工单管理 (Ticket Management)
-- [ ] ⏸️ 06_ticket_management/00_intro.md
-- [ ] ⏸️ 06_ticket_management/01_arrays.md
-- [ ] ⏸️ 06_ticket_management/02_vec.md
-- [ ] ⏸️ 06_ticket_management/03_resizing.md
-- [ ] ⏸️ 06_ticket_management/04_iterators.md
-- [ ] ⏸️ 06_ticket_management/05_iter.md
-- [ ] ⏸️ 06_ticket_management/06_lifetimes.md
-- [ ] ⏸️ 06_ticket_management/07_combinators.md
-- [ ] ⏸️ 06_ticket_management/08_impl_trait.md
-- [ ] ⏸️ 06_ticket_management/09_impl_trait_2.md
-- [ ] ⏸️ 06_ticket_management/10_slices.md
-- [ ] ⏸️ 06_ticket_management/11_mutable_slices.md
-- [ ] ⏸️ 06_ticket_management/12_two_states.md
-- [ ] ⏸️ 06_ticket_management/13_index.md
-- [ ] ⏸️ 06_ticket_management/14_index_mut.md
-- [ ] ⏸️ 06_ticket_management/15_hashmap.md
-- [ ] ⏸️ 06_ticket_management/16_btreemap.md
+- [x] ✅ 06_ticket_management/00_intro.md
+- [x] ✅ 06_ticket_management/01_arrays.md
+- [x] ✅ 06_ticket_management/02_vec.md
+- [x] ✅ 06_ticket_management/03_resizing.md
+- [x] ✅ 06_ticket_management/04_iterators.md
+- [x] ✅ 06_ticket_management/05_iter.md
+- [x] ✅ 06_ticket_management/06_lifetimes.md
+- [x] ✅ 06_ticket_management/07_combinators.md
+- [x] ✅ 06_ticket_management/08_impl_trait.md
+- [x] ✅ 06_ticket_management/09_impl_trait_2.md
+- [x] ✅ 06_ticket_management/10_slices.md
+- [x] ✅ 06_ticket_management/11_mutable_slices.md
+- [x] ✅ 06_ticket_management/12_two_states.md
+- [x] ✅ 06_ticket_management/13_index.md
+- [x] ✅ 06_ticket_management/14_index_mut.md
+- [x] ✅ 06_ticket_management/15_hashmap.md
+- [x] ✅ 06_ticket_management/16_btreemap.md
 
 ### 第7章：线程 (Threads)
 - [ ] ⏸️ 07_threads/00_intro.md

--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -1,7 +1,7 @@
 # 欢迎
 
 > 🌏 **中文版说明**
-> 本书正在翻译中，当前进度约 58%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
+> 本书正在翻译中，当前进度约 75%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
 > 英文原版请访问 [rust-exercises.com](https://rust-exercises.com)。
 > 翻译问题请提交到 [GitHub Issues](https://github.com/tangivis/100-exercises-to-learn-rust/issues)。
 

--- a/book/src/06_ticket_management/00_intro.md
+++ b/book/src/06_ticket_management/00_intro.md
@@ -1,18 +1,18 @@
-# Intro
+# 引入 (Intro)
 
-In the previous chapter we modelled `Ticket` in a vacuum: we defined its fields and their constraints, we learned
-how to best represent them in Rust, but we didn't consider how `Ticket` fits into a larger system.
-We'll use this chapter to build a simple workflow around `Ticket`, introducing a (rudimentary) management system to
-store and retrieve tickets.
+上一章我们在真空中对 `Ticket` 进行建模：定义了字段及其约束，学习了如何在 Rust 中尽量好地表达它们，但没有考虑 `Ticket` 在更大系统中的位置。
+本章我们要围绕 `Ticket` 构建一个简单的工作流，引入一个（粗糙的）管理系统来存储和检索工单。
 
-The task will give us an opportunity to explore new Rust concepts, such as:
+任务会让我们有机会探索新的 Rust 概念，例如：
 
-- Stack-allocated arrays
-- `Vec`, a growable array type
-- `Iterator` and `IntoIterator`, for iterating over collections
-- Slices (`&[T]`), to work with parts of a collection
-- Lifetimes, to describe how long references are valid
-- `HashMap` and `BTreeMap`, two key-value data structures
-- `Eq` and `Hash`, to compare keys in a `HashMap`
-- `Ord` and `PartialOrd`, to work with a `BTreeMap`
-- `Index` and `IndexMut`, to access elements in a collection
+- 栈分配的数组 (Stack-allocated arrays)
+- `Vec`，可增长的数组类型
+- `Iterator` 与 `IntoIterator`，用于在集合上迭代
+- 切片 (slice) `&[T]`，用于处理集合的一部分
+- 生命周期 (lifetime)，用于描述引用有效多久
+- `HashMap` 与 `BTreeMap`，两个键值数据结构
+- `Eq` 与 `Hash`，用于在 `HashMap` 中比较键
+- `Ord` 与 `PartialOrd`，用于操作 `BTreeMap`
+- `Index` 与 `IndexMut`，用于访问集合中的元素
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/00_intro.md)

--- a/book/src/06_ticket_management/01_arrays.md
+++ b/book/src/06_ticket_management/01_arrays.md
@@ -1,38 +1,38 @@
-# Arrays
+# 数组 (Arrays)
 
-As soon as we start talking about "ticket management" we need to think about a way to store _multiple_ tickets.
-In turn, this means we need to think about collections. In particular, homogeneous collections:
-we want to store multiple instances of the same type.
+一谈到"工单管理 (ticket management)"，我们就要想办法存储 _多张_ 工单。
+这又意味着我们需要思考集合 (collection)。具体来说，是同质 (homogeneous) 集合：
+我们想存储同一类型的多个实例。
 
-What does Rust have to offer in this regard?
+Rust 在这方面提供了什么？
 
-## Arrays
+## 数组 (Arrays)
 
-A first attempt could be to use an **array**.\
-Arrays in Rust are fixed-size collections of elements of the same type.
+第一种尝试是使用**数组 (array)**。\
+Rust 中的数组是相同类型元素的固定大小集合。
 
-Here's how you can define an array:
+下面是数组的定义方式：
 
 ```rust
-// Array type syntax: [ <type> ; <number of elements> ]
+// 数组类型语法：[ <类型> ; <元素数量> ]
 let numbers: [u32; 3] = [1, 2, 3];
 ```
 
-This creates an array of 3 integers, initialized with the values `1`, `2`, and `3`.\
-The type of the array is `[u32; 3]`, which reads as "an array of `u32`s with a length of 3".
+这创建了一个由 3 个整数组成的数组，初始化为 `1`、`2`、`3`。\
+该数组的类型是 `[u32; 3]`，读作"长度为 3 的 `u32` 数组"。
 
-If all array elements are the same, you can use a shorter syntax to initialize it:
+如果数组所有元素相同，可以用更短的语法初始化：
 
 ```rust
-// [ <value> ; <number of elements> ]
+// [ <值> ; <元素数量> ]
 let numbers: [u32; 3] = [1; 3];
 ```
 
-`[1; 3]` creates an array of three elements, all equal to `1`.
+`[1; 3]` 创建一个三元素数组，元素全为 `1`。
 
-### Accessing elements
+### 访问元素 (Accessing elements)
 
-You can access elements of an array using square brackets:
+可以用方括号访问数组元素：
 
 ```rust
 let first = numbers[0];
@@ -40,44 +40,41 @@ let second = numbers[1];
 let third = numbers[2];
 ```
 
-The index must be of type `usize`.\
-Arrays are **zero-indexed**, like everything in Rust. You've seen this before with string slices and field indexing in
-tuples/tuple-like variants.
+索引必须是 `usize` 类型。\
+跟 Rust 中其他东西一样，数组是**从 0 开始计索引 (zero-indexed)** 的。你之前在字符串切片以及元组/类元组变体的字段索引中见过这点。
 
-### Out-of-bounds access
+### 越界访问 (Out-of-bounds access)
 
-If you try to access an element that's out of bounds, Rust will panic:
+如果你尝试访问越界的元素，Rust 会 panic：
 
 ```rust
 let numbers: [u32; 3] = [1, 2, 3];
-let fourth = numbers[3]; // This will panic
+let fourth = numbers[3]; // 这里会 panic
 ```
 
-This is enforced at runtime using **bounds checking**. It comes with a small performance overhead, but it's how
-Rust prevents buffer overflows.\
-In some scenarios the Rust compiler can optimize away bounds checks, especially if iterators are involved—we'll speak
-more about this later on.
+这是通过运行时的**边界检查 (bounds checking)** 强制执行的。它会带来少量性能开销，但这就是 Rust 防止缓冲区溢出 (buffer overflow) 的方式。\
+某些情况下 Rust 编译器可以把边界检查优化掉，特别是涉及迭代器时——这点稍后会再细谈。
 
-If you don't want to panic, you can use the `get` method, which returns an `Option<&T>`:
+如果不想 panic，可以用 `get` 方法，它返回 `Option<&T>`：
 
 ```rust
 let numbers: [u32; 3] = [1, 2, 3];
 assert_eq!(numbers.get(0), Some(&1));
-// You get a `None` if you try to access an out-of-bounds index
-// rather than a panic.
+// 越界时返回 `None`，
+// 而不是 panic。
 assert_eq!(numbers.get(3), None);
 ```
 
-### Performance
+### 性能 (Performance)
 
-Since the size of an array is known at compile-time, the compiler can allocate the array on the stack.
-If you run the following code:
+由于数组的大小在编译期已知，编译器可以把数组分配在栈上。
+如果你运行下面的代码：
 
 ```rust
 let numbers: [u32; 3] = [1, 2, 3];
 ```
 
-You'll get the following memory layout:
+会得到这样的内存布局：
 
 ```text
         +---+---+---+
@@ -85,6 +82,7 @@ Stack:  | 1 | 2 | 3 |
         +---+---+---+
 ```
 
-In other words, the size of an array is `std::mem::size_of::<T>() * N`, where `T` is the type of the elements and `N` is
-the number of elements.\
-You can access and replace each element in `O(1)` time.
+换言之，数组的大小是 `std::mem::size_of::<T>() * N`，其中 `T` 是元素类型，`N` 是元素数量。\
+你可以以 `O(1)` 时间访问和替换每个元素。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/01_arrays.md)

--- a/book/src/06_ticket_management/02_vec.md
+++ b/book/src/06_ticket_management/02_vec.md
@@ -1,7 +1,7 @@
-# Vectors
+# 向量 (Vectors)
 
-Arrays' strength is also their weakness: their size must be known upfront, at compile-time.
-If you try to create an array with a size that's only known at runtime, you'll get a compilation error:
+数组的优点也是它的弱点：大小必须在编译期就已知。
+如果你尝试创建一个大小只有运行时才能知道的数组，会得到编译错误：
 
 ```rust
 let n = 10;
@@ -17,19 +17,19 @@ error[E0435]: attempt to use a non-constant value in a constant
   |                    ^ non-constant value
 ```
 
-Arrays wouldn't work for our ticket management system—we don't know how many tickets we'll need to store at compile-time.
-This is where `Vec` comes in.
+数组无法满足我们的工单管理系统——我们在编译期不知道要存多少工单。
+这就是 `Vec` 出场的时候。
 
 ## `Vec`
 
-`Vec` is a growable array type, provided by the standard library.\
-You can create an empty array using the `Vec::new` function:
+`Vec` 是标准库提供的可增长数组类型。\
+你可以用 `Vec::new` 函数创建一个空数组：
 
 ```rust
 let mut numbers: Vec<u32> = Vec::new();
 ```
 
-You would then push elements into the vector using the `push` method:
+然后用 `push` 方法把元素压入向量：
 
 ```rust
 numbers.push(1);
@@ -37,16 +37,16 @@ numbers.push(2);
 numbers.push(3);
 ```
 
-New values are added to the end of the vector.\
-You can also create an initialized vector using the `vec!` macro, if you know the values at creation time:
+新值会被加到向量末尾。\
+如果你在创建时就知道值，也可以用 `vec!` 宏创建一个已初始化的向量：
 
 ```rust
 let numbers = vec![1, 2, 3];
 ```
 
-## Accessing elements
+## 访问元素 (Accessing elements)
 
-The syntax for accessing elements is the same as with arrays:
+访问元素的语法跟数组相同：
 
 ```rust
 let numbers = vec![1, 2, 3];
@@ -55,25 +55,25 @@ let second = numbers[1];
 let third = numbers[2];
 ```
 
-The index must be of type `usize`.\
-You can also use the `get` method, which returns an `Option<&T>`:
+索引必须是 `usize` 类型。\
+也可以用 `get` 方法，返回 `Option<&T>`：
 
 ```rust
 let numbers = vec![1, 2, 3];
 assert_eq!(numbers.get(0), Some(&1));
-// You get a `None` if you try to access an out-of-bounds index
-// rather than a panic.
+// 越界时返回 `None`，
+// 而不是 panic。
 assert_eq!(numbers.get(3), None);
 ```
 
-Access is bounds-checked, just like element access with arrays. It has O(1) complexity.
+访问会做边界检查，跟数组的元素访问一样，复杂度是 O(1)。
 
-## Memory layout
+## 内存布局 (Memory layout)
 
-`Vec` is a heap-allocated data structure.\
-When you create a `Vec`, it allocates memory on the heap to store the elements.
+`Vec` 是堆分配 (heap-allocated) 的数据结构。\
+你创建 `Vec` 时，它在堆上分配内存来存储元素。
 
-If you run the following code:
+如果你运行下面的代码：
 
 ```rust
 let mut numbers = Vec::with_capacity(3);
@@ -81,7 +81,7 @@ numbers.push(1);
 numbers.push(2);
 ```
 
-you'll get the following memory layout:
+会得到这样的内存布局：
 
 ```text
       +---------+--------+----------+
@@ -96,17 +96,19 @@ Heap:  | 1 | 2 | ? |
        +---+---+---+
 ```
 
-`Vec` keeps track of three things:
+`Vec` 跟踪三件事：
 
-- The **pointer** to the heap region you reserved.
-- The **length** of the vector, i.e. how many elements are in the vector.
-- The **capacity** of the vector, i.e. the number of elements that can fit in the space reserved on the heap.
+- 指向你在堆上预留区域的**指针 (pointer)**。
+- 向量的**长度 (length)**，即向量中有多少元素。
+- 向量的**容量 (capacity)**，即在堆上预留的空间能装多少元素。
 
-This layout should look familiar: it's exactly the same as `String`!\
-That's not a coincidence: `String` is defined as a vector of bytes, `Vec<u8>`, under the hood:
+这种布局看起来应当很眼熟：和 `String` 完全一样！\
+这不是巧合：`String` 在底层就是定义为字节向量 `Vec<u8>`：
 
 ```rust
 pub struct String {
     vec: Vec<u8>,
 }
 ```
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/02_vec.md)

--- a/book/src/06_ticket_management/03_resizing.md
+++ b/book/src/06_ticket_management/03_resizing.md
@@ -1,25 +1,26 @@
-# Resizing
+# 调整大小 (Resizing)
 
-We said that `Vec` is a "growable" vector type, but what does that mean?
-What happens if you try to insert an element into a `Vec` that's already at maximum capacity?
+我们说 `Vec` 是"可增长"的向量类型，但这究竟意味着什么？
+如果你尝试向已经达到最大容量的 `Vec` 中插入元素，会发生什么？
 
 ```rust
 let mut numbers = Vec::with_capacity(3);
 numbers.push(1);
 numbers.push(2);
-numbers.push(3); // Max capacity reached
-numbers.push(4); // What happens here?
+numbers.push(3); // 已达最大容量
+numbers.push(4); // 这里会发生什么？
 ```
 
-The `Vec` will **resize** itself.\
-It will ask the allocator for a new (larger) chunk of heap memory, copy the elements over, and deallocate the old memory.
+`Vec` 会**调整自身大小 (resize)**。\
+它会向分配器请求一块新的（更大的）堆内存，把元素复制过去，然后释放旧内存。
 
-This operation can be expensive, as it involves a new memory allocation and copying all existing elements.
+这个操作可能很昂贵，因为它涉及一次新的内存分配以及把所有现有元素复制过去。
 
 ## `Vec::with_capacity`
 
-If you have a rough idea of how many elements you'll store in a `Vec`, you can use the `Vec::with_capacity`
-method to pre-allocate enough memory upfront.\
-This can avoid a new allocation when the `Vec` grows, but it may waste memory if you overestimate actual usage.
+如果你大致知道要在 `Vec` 中存多少元素，可以用 `Vec::with_capacity` 方法预先分配足够的内存。\
+这能避免 `Vec` 增长时的一次新分配，但如果你高估了实际用量，也会浪费内存。
 
-Evaluate on a case-by-case basis.
+依个案权衡。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/03_resizing.md)

--- a/book/src/06_ticket_management/04_iterators.md
+++ b/book/src/06_ticket_management/04_iterators.md
@@ -1,27 +1,27 @@
-# Iteration
+# 迭代 (Iteration)
 
-During the very first exercises, you learned that Rust lets you iterate over collections using `for` loops.
-We were looking at ranges at that point (e.g. `0..5`), but the same holds true for collections like arrays and vectors.
+最早的练习里，你已经了解到 Rust 允许你用 `for` 循环遍历集合。
+当时我们看的是范围（例如 `0..5`），但同样的规则也适用于像数组和向量这样的集合。
 
 ```rust
-// It works for `Vec`s
+// 适用于 `Vec`
 let v = vec![1, 2, 3];
 for n in v {
     println!("{}", n);
 }
 
-// It also works for arrays
+// 也适用于数组
 let a: [u32; 3] = [1, 2, 3];
 for n in a {
     println!("{}", n);
 }
 ```
 
-It's time to understand how this works under the hood.
+是时候了解它在底层是如何工作的了。
 
-## `for` desugaring
+## `for` 的脱糖 (`for` desugaring)
 
-Every time you write a `for` loop in Rust, the compiler _desugars_ it into the following code:
+每当你在 Rust 里写 `for` 循环时，编译器会把它 _脱糖 (desugar)_ 成下面这样的代码：
 
 ```rust
 let mut iter = IntoIterator::into_iter(v);
@@ -35,14 +35,13 @@ loop {
 }
 ```
 
-`loop` is another looping construct, on top of `for` and `while`.\
-A `loop` block will run forever, unless you explicitly `break` out of it.
+`loop` 是除 `for` 和 `while` 之外的另一种循环构造。\
+`loop` 块会无限运行，除非你显式 `break`。
 
-## `Iterator` trait
+## `Iterator` 特质 (`Iterator` trait)
 
-The `next` method in the previous code snippet comes from the `Iterator` trait.
-The `Iterator` trait is defined in Rust's standard library and provides a shared interface for
-types that can produce a sequence of values:
+前面代码片段中的 `next` 方法来自 `Iterator` 特质。
+`Iterator` 特质定义在 Rust 标准库中，为能够产生一系列值的类型提供共享接口：
 
 ```rust
 trait Iterator {
@@ -51,19 +50,17 @@ trait Iterator {
 }
 ```
 
-The `Item` associated type specifies the type of the values produced by the iterator.
+`Item` 关联类型 (associated type) 指定了迭代器产生的值的类型。
 
-`next` returns the next value in the sequence.\
-It returns `Some(value)` if there's a value to return, and `None` when there isn't.
+`next` 返回序列中的下一个值。\
+如果有值可返回则返回 `Some(value)`，没有则返回 `None`。
 
-Be careful: there is no guarantee that an iterator is exhausted when it returns `None`. That's only
-guaranteed if the iterator implements the (more restrictive)
-[`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html) trait.
+注意：迭代器返回 `None` 不保证它已经耗尽。这只在迭代器实现了（更严格的）[`FusedIterator`](https://doc.rust-lang.org/std/iter/trait.FusedIterator.html) 特质时才能保证。
 
-## `IntoIterator` trait
+## `IntoIterator` 特质 (`IntoIterator` trait)
 
-Not all types implement `Iterator`, but many can be converted into a type that does.\
-That's where the `IntoIterator` trait comes in:
+并不是所有类型都实现了 `Iterator`，但很多类型可以转换成实现了 `Iterator` 的类型。\
+这就是 `IntoIterator` 特质的用武之地：
 
 ```rust
 trait IntoIterator {
@@ -73,18 +70,18 @@ trait IntoIterator {
 }
 ```
 
-The `into_iter` method consumes the original value and returns an iterator over its elements.\
-A type can only have one implementation of `IntoIterator`: there can be no ambiguity as to what `for` should desugar to.
+`into_iter` 方法消费原值，返回它的元素上的迭代器。\
+一个类型只能有一个 `IntoIterator` 实现：`for` 该脱糖成什么不能有歧义。
 
-One detail: every type that implements `Iterator` automatically implements `IntoIterator` as well.
-They just return themselves from `into_iter`!
+一个细节：每个实现了 `Iterator` 的类型也自动实现了 `IntoIterator`。
+它们的 `into_iter` 直接返回自身！
 
-## Bounds checks
+## 边界检查 (Bounds checks)
 
-Iterating over iterators has a nice side effect: you can't go out of bounds, by design.\
-This allows Rust to remove bounds checks from the generated machine code, making iteration faster.
+迭代有一个不错的副作用：按设计你不会越界。\
+这允许 Rust 在生成的机器码中去掉边界检查，使迭代更快。
 
-In other words,
+换句话说，
 
 ```rust
 let v = vec![1, 2, 3];
@@ -93,7 +90,7 @@ for n in v {
 }
 ```
 
-is usually faster than
+通常比
 
 ```rust
 let v = vec![1, 2, 3];
@@ -102,6 +99,8 @@ for i in 0..v.len() {
 }
 ```
 
-There are exceptions to this rule: the compiler can sometimes prove that you're not going out of bounds even
-with manual indexing, thus removing the bounds checks anyway. But in general, prefer iteration to indexing
-where possible.
+更快。
+
+这条规则有例外：编译器有时能证明你没有越界，即使是手动索引也能去掉边界检查。但总的来说，能用迭代就别用索引。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/04_iterators.md)

--- a/book/src/06_ticket_management/05_iter.md
+++ b/book/src/06_ticket_management/05_iter.md
@@ -1,42 +1,44 @@
 # `.iter()`
 
-`IntoIterator` **consumes** `self` to create an iterator.
+`IntoIterator` 会**消费 (consume)** `self` 来创建迭代器。
 
-This has its benefits: you get **owned** values from the iterator.
-For example: if you call `.into_iter()` on a `Vec<Ticket>` you'll get an iterator that returns `Ticket` values.
+这有它的好处：你从迭代器拿到的是**拥有所有权 (owned)** 的值。
+例如：在 `Vec<Ticket>` 上调用 `.into_iter()` 会得到一个返回 `Ticket` 值的迭代器。
 
-That's also its downside: you can no longer use the original collection after calling `.into_iter()` on it.
-Quite often you want to iterate over a collection without consuming it, looking at **references** to the values instead.
-In the case of `Vec<Ticket>`, you'd want to iterate over `&Ticket` values.
+这也有缺点：调用 `.into_iter()` 之后你就不能再使用原集合了。
+很多时候你想在不消费集合的前提下遍历它，看到值的**引用 (reference)**。
+对 `Vec<Ticket>` 来说，你想要的是遍历 `&Ticket` 值。
 
-Most collections expose a method called `.iter()` that returns an iterator over references to the collection's elements.
-For example:
+大多数集合都暴露了一个 `.iter()` 方法，返回对集合元素引用的迭代器。
+例如：
 
 ```rust
 let numbers: Vec<u32> = vec![1, 2];
-// `n` has type `&u32` here
+// 这里 `n` 的类型是 `&u32`
 for n in numbers.iter() {
     // [...]
 }
 ```
 
-This pattern can be simplified by implementing `IntoIterator` for a **reference to the collection**.
-In our example above, that would be `&Vec<Ticket>`.\
-The standard library does this, that's why the following code works:
+这种模式可以通过为**对集合的引用**实现 `IntoIterator` 来简化。
+上面的例子中就是 `&Vec<Ticket>`。\
+标准库这样做了，所以下面的代码可以工作：
 
 ```rust
 let numbers: Vec<u32> = vec![1, 2];
-// `n` has type `&u32` here
-// We didn't have to call `.iter()` explicitly
-// It was enough to use `&numbers` in the `for` loop
+// 这里 `n` 的类型是 `&u32`
+// 我们没有显式调用 `.iter()`
+// 在 `for` 循环中使用 `&numbers` 就够了
 for n in &numbers {
     // [...]
 }
 ```
 
-It's idiomatic to provide both options:
+习惯上同时提供两种方式：
 
-- An implementation of `IntoIterator` for a reference to the collection.
-- An `.iter()` method that returns an iterator over references to the collection's elements.
+- 为对集合的引用实现 `IntoIterator`。
+- 一个返回对集合元素引用的迭代器的 `.iter()` 方法。
 
-The former is convenient in `for` loops, the latter is more explicit and can be used in other contexts.
+前者在 `for` 循环里方便，后者更显式，可以在其他场景使用。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/05_iter.md)

--- a/book/src/06_ticket_management/06_lifetimes.md
+++ b/book/src/06_ticket_management/06_lifetimes.md
@@ -1,14 +1,13 @@
-# Lifetimes
+# 生命周期 (Lifetimes)
 
-Let's try to complete the previous exercise by adding an implementation of `IntoIterator` for `&TicketStore`, for
-maximum convenience in `for` loops.
+为了在 `for` 循环中获得最大便利，我们尝试通过为 `&TicketStore` 实现 `IntoIterator` 来完成前一个练习。
 
-Let's start by filling in the most "obvious" parts of the implementation:
+先填上实现中最"显而易见"的部分：
 
 ```rust
 impl IntoIterator for &TicketStore {
     type Item = &Ticket;
-    type IntoIter = // What goes here?
+    type IntoIter = // 这里写什么？
 
     fn into_iter(self) -> Self::IntoIter {
         self.tickets.iter()
@@ -16,51 +15,48 @@ impl IntoIterator for &TicketStore {
 }
 ```
 
-What should `type IntoIter` be set to?\
-Intuitively, it should be the type returned by `self.tickets.iter()`, i.e. the type returned by `Vec::iter()`.\
-If you check the standard library documentation, you'll find that `Vec::iter()` returns an `std::slice::Iter`.
-The definition of `Iter` is:
+`type IntoIter` 应当是什么？\
+直觉上，应当是 `self.tickets.iter()` 返回的类型，也就是 `Vec::iter()` 返回的类型。\
+查看标准库文档可以发现 `Vec::iter()` 返回 `std::slice::Iter`。
+`Iter` 的定义是：
 
 ```rust
-pub struct Iter<'a, T> { /* fields omitted */ }
+pub struct Iter<'a, T> { /* 字段省略 */ }
 ```
 
-`'a` is a **lifetime parameter**.
+`'a` 是一个**生命周期参数 (lifetime parameter)**。
 
-## Lifetime parameters
+## 生命周期参数 (Lifetime parameters)
 
-Lifetimes are **labels** used by the Rust compiler to keep track of how long a reference (either mutable or
-immutable) is valid.\
-The lifetime of a reference is constrained by the scope of the value it refers to. Rust always makes sure, at compile-time,
-that references are not used after the value they refer to has been dropped, to avoid dangling pointers and use-after-free bugs.
+生命周期 (lifetime) 是 Rust 编译器用来跟踪某个引用（不论可变还是不可变）有效多久的**标签 (label)**。\
+引用的生命周期受它所引用的值的作用域 (scope) 约束。Rust 总是在编译期确保引用不会在它所指向的值被丢弃之后再被使用，从而避免悬垂指针 (dangling pointer) 与释放后使用 (use-after-free) bug。
 
-This should sound familiar: we've already seen these concepts in action when we discussed ownership and borrowing.
-Lifetimes are just a way to **name** how long a specific reference is valid.
+这听起来应该很熟悉：我们在讨论所有权与借用时已经看过这些概念在起作用。
+生命周期只是一种**命名 (name)** 某个引用有效多久的方式。
 
-Naming becomes important when you have multiple references and you need to clarify how they **relate to each other**.
-Let's look at the signature of `Vec::iter()`:
+当你有多个引用、需要明确它们之间的**关系**时，命名变得重要。
+我们看看 `Vec::iter()` 的签名：
 
 ```rust
 impl <T> Vec<T> {
-    // Slightly simplified
+    // 略简化
     pub fn iter<'a>(&'a self) -> Iter<'a, T> {
         // [...]
     }
 }
 ```
 
-`Vec::iter()` is generic over a lifetime parameter, named `'a`.\
-`'a` is used to **tie together** the lifetime of the `Vec` and the lifetime of the `Iter` returned by `iter()`.
-In plain English: the `Iter` returned by `iter()` cannot outlive the `Vec` reference (`&self`) it was created from.
+`Vec::iter()` 是一个对生命周期参数 `'a` 泛型的函数。\
+`'a` 用于把 `Vec` 的生命周期与 `iter()` 返回的 `Iter` 的生命周期**绑定 (tie together)** 起来。
+用大白话说：`iter()` 返回的 `Iter` 不能比创建它的 `Vec` 引用 (`&self`) 活得更久。
 
-This is important because `Vec::iter`, as we discussed, returns an iterator over **references** to the `Vec`'s elements.
-If the `Vec` is dropped, the references returned by the iterator would be invalid. Rust must make sure this doesn't happen,
-and lifetimes are the tool it uses to enforce this rule.
+这一点很重要，因为正如我们讨论过的，`Vec::iter` 返回的迭代器是对 `Vec` 元素**引用**的迭代器。
+如果 `Vec` 被丢弃，迭代器返回的引用就失效了。Rust 必须确保这不会发生，生命周期就是它用来强制执行这条规则的工具。
 
-## Lifetime elision
+## 生命周期省略 (Lifetime elision)
 
-Rust has a set of rules, called **lifetime elision rules**, that allow you to omit explicit lifetime annotations in many cases.
-For example, `Vec::iter`'s definition looks like this in `std`'s source code:
+Rust 有一组**生命周期省略规则 (lifetime elision rules)**，允许你在很多场合省略显式的生命周期标注。
+例如，`Vec::iter` 在 `std` 源码中的定义是这样的：
 
 ```rust
 impl <T> Vec<T> {
@@ -70,15 +66,17 @@ impl <T> Vec<T> {
 }
 ```
 
-No explicit lifetime parameter is present in the signature of `Vec::iter()`.
-Elision rules imply that the lifetime of the `Iter` returned by `iter()` is tied to the lifetime of the `&self` reference.
-You can think of `'_` as a **placeholder** for the lifetime of the `&self` reference.
+`Vec::iter()` 的签名中没有出现显式的生命周期参数。
+省略规则意味着 `iter()` 返回的 `Iter` 的生命周期与 `&self` 引用的生命周期绑定。
+你可以把 `'_` 看作 `&self` 引用生命周期的**占位符 (placeholder)**。
 
-See the [References](#references) section for a link to the official documentation on lifetime elision.\
-In most cases, you can rely on the compiler telling you when you need to add explicit lifetime annotations.
+参见[参考资料 (References)](#参考资料-references) 一节获取生命周期省略的官方文档链接。\
+大多数情况下，你可以依赖编译器在你需要添加显式生命周期标注时给出提示。
 
-## References
+## 参考资料 (References)
 
 - [std::vec::Vec::iter](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.iter)
 - [std::slice::Iter](https://doc.rust-lang.org/std/slice/struct.Iter.html)
 - [Lifetime elision rules](https://doc.rust-lang.org/reference/lifetime-elision.html)
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/06_lifetimes.md)

--- a/book/src/06_ticket_management/07_combinators.md
+++ b/book/src/06_ticket_management/07_combinators.md
@@ -1,57 +1,56 @@
-# Combinators
+# 组合子 (Combinators)
 
-Iterators can do so much more than `for` loops!\
-If you look at the documentation for the `Iterator` trait, you'll find a **vast** collection of
-methods that you can leverage to transform, filter, and combine iterators in various ways.
+迭代器能做的远不止 `for` 循环！\
+查看 `Iterator` 特质的文档，你会发现一个**庞大**的方法集合，可用于以各种方式变换、过滤、组合迭代器。
 
-Let's mention the most common ones:
+我们说说最常见的几个：
 
-- `map` applies a function to each element of the iterator.
-- `filter` keeps only the elements that satisfy a predicate.
-- `filter_map` combines `filter` and `map` in one step.
-- `cloned` converts an iterator of references into an iterator of values, cloning each element.
-- `enumerate` returns a new iterator that yields `(index, value)` pairs.
-- `skip` skips the first `n` elements of the iterator.
-- `take` stops the iterator after `n` elements.
-- `chain` combines two iterators into one.
+- `map`：对迭代器的每个元素应用一个函数。
+- `filter`：只保留满足某谓词 (predicate) 的元素。
+- `filter_map`：一步完成 `filter` 和 `map`。
+- `cloned`：把对引用的迭代器转换为值的迭代器，对每个元素进行克隆 (clone)。
+- `enumerate`：返回一个产生 `(index, value)` 对的新迭代器。
+- `skip`：跳过迭代器的前 `n` 个元素。
+- `take`：在 `n` 个元素后停止迭代器。
+- `chain`：把两个迭代器合为一个。
 
-These methods are called **combinators**.\
-They are usually **chained** together to create complex transformations in a concise and readable way:
+这些方法被称作**组合子 (combinator)**。\
+通常**链式 (chained)** 调用，从而以简洁可读的方式构造复杂变换：
 
 ```rust
 let numbers = vec![1, 2, 3, 4, 5];
-// The sum of the squares of the even numbers
+// 偶数平方和
 let outcome: u32 = numbers.iter()
     .filter(|&n| n % 2 == 0)
     .map(|&n| n * n)
     .sum();
 ```
 
-## Closures
+## 闭包 (Closures)
 
-What's going on with the `filter` and `map` methods above?\
-They take **closures** as arguments.
+上面的 `filter` 和 `map` 方法在做什么？\
+它们以**闭包 (closure)** 作为参数。
 
-Closures are **anonymous functions**, i.e. functions that are not defined using the `fn` syntax we are used to.\
-They are defined using the `|args| body` syntax, where `args` are the arguments and `body` is the function body.
-`body` can be a block of code or a single expression.
-For example:
+闭包是**匿名函数 (anonymous function)**，即不通过我们熟悉的 `fn` 语法定义的函数。\
+它们用 `|args| body` 语法定义，`args` 是参数，`body` 是函数体。
+`body` 可以是一段代码块或单个表达式。
+例如：
 
 ```rust
-// An anonymous function that adds 1 to its argument
+// 一个匿名函数，把参数加 1
 let add_one = |x| x + 1;
-// Could be written with a block too:
+// 也可以用代码块写：
 let add_one = |x| { x + 1 };
 ```
 
-Closures can take more than one argument:
+闭包可以接收多个参数：
 
 ```rust
 let add = |x, y| x + y;
 let sum = add(1, 2);
 ```
 
-They can also capture variables from their environment:
+它们也能从环境中捕获 (capture) 变量：
 
 ```rust
 let x = 42;
@@ -59,24 +58,24 @@ let add_x = |y| x + y;
 let sum = add_x(1);
 ```
 
-If necessary, you can specify the types of the arguments and/or the return type:
+如有需要，可以指定参数和/或返回类型：
 
 ```rust
-// Just the input type
+// 只标注输入类型
 let add_one = |x: i32| x + 1;
-// Or both input and output types, using the `fn` syntax
+// 也可以使用 `fn` 语法标注输入和输出
 let add_one: fn(i32) -> i32 = |x| x + 1;
 ```
 
 ## `collect`
 
-What happens when you're done transforming an iterator using combinators?\
-You either iterate over the transformed values using a `for` loop, or you collect them into a collection.
+用组合子变换完一个迭代器之后，要做什么？\
+你要么用 `for` 循环遍历变换后的值，要么把它们收集到一个集合里。
 
-The latter is done using the `collect` method.\
-`collect` consumes the iterator and collects its elements into a collection of your choice.
+后者是用 `collect` 方法完成。\
+`collect` 消费迭代器，把它的元素收集到你选择的集合里。
 
-For example, you can collect the squares of the even numbers into a `Vec`:
+例如，可以把偶数的平方收集到 `Vec` 中：
 
 ```rust
 let numbers = vec![1, 2, 3, 4, 5];
@@ -86,22 +85,24 @@ let squares_of_evens: Vec<u32> = numbers.iter()
     .collect();
 ```
 
-`collect` is generic over its **return type**.\
-Therefore you usually need to provide a type hint to help the compiler infer the correct type.
-In the example above, we annotated the type of `squares_of_evens` to be `Vec<u32>`.
-Alternatively, you can use the **turbofish syntax** to specify the type:
+`collect` 对其**返回类型 (return type)** 是泛型的。\
+所以你通常需要给出类型提示来帮编译器推断正确类型。
+上面的例子中，我们把 `squares_of_evens` 的类型标注为 `Vec<u32>`。
+或者你也可以用**鱼叉语法 (turbofish syntax)** 来指定类型：
 
 ```rust
 let squares_of_evens = numbers.iter()
     .filter(|&n| n % 2 == 0)
     .map(|&n| n * n)
-    // Turbofish syntax: `<method_name>::<type>()`
-    // It's called turbofish because `::<>` looks like a fish
+    // 鱼叉语法：`<方法名>::<类型>()`
+    // 之所以叫 turbofish，是因为 `::<>` 看起来像一条鱼
     .collect::<Vec<u32>>();
 ```
 
-## Further reading
+## 进一步阅读
 
-- [`Iterator`'s documentation](https://doc.rust-lang.org/std/iter/trait.Iterator.html) gives you an
-  overview of the methods available for iterators in `std`.
-- [The `itertools` crate](https://docs.rs/itertools/) defines even **more** combinators for iterators.
+- [`Iterator` 的文档](https://doc.rust-lang.org/std/iter/trait.Iterator.html)
+  概览了 `std` 中迭代器可用的方法。
+- [`itertools` crate](https://docs.rs/itertools/) 为迭代器定义了**更多**组合子。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/07_combinators.md)

--- a/book/src/06_ticket_management/08_impl_trait.md
+++ b/book/src/06_ticket_management/08_impl_trait.md
@@ -1,13 +1,11 @@
 # `impl Trait`
 
-`TicketStore::to_dos` returns a `Vec<&Ticket>`.\
-That signature introduces a new heap allocation every time `to_dos` is called, which may be unnecessary depending
-on what the caller needs to do with the result.
-It'd be better if `to_dos` returned an iterator instead of a `Vec`, thus empowering the caller to decide whether to
-collect the results into a `Vec` or just iterate over them.
+`TicketStore::to_dos` 返回 `Vec<&Ticket>`。\
+这个签名意味着每次调用 `to_dos` 都会引入一次新的堆分配——这有时是不必要的，取决于调用方对结果做什么。
+如果 `to_dos` 返回迭代器而非 `Vec` 会更好，让调用方自行决定要不要把结果收集到 `Vec` 里、还是直接遍历。
 
-That's tricky though!
-What's the return type of `to_dos`, as implemented below?
+但这有点棘手！
+下面这段实现里 `to_dos` 的返回类型该是什么？
 
 ```rust
 impl TicketStore {
@@ -17,27 +15,26 @@ impl TicketStore {
 }
 ```
 
-## Unnameable types
+## 不可命名的类型 (Unnameable types)
 
-The `filter` method returns an instance of `std::iter::Filter`, which has the following definition:
+`filter` 方法返回一个 `std::iter::Filter` 实例，其定义为：
 
 ```rust
-pub struct Filter<I, P> { /* fields omitted */ }
+pub struct Filter<I, P> { /* 字段省略 */ }
 ```
 
-where `I` is the type of the iterator being filtered on and `P` is the predicate used to filter the elements.\
-We know that `I` is `std::slice::Iter<'_, Ticket>` in this case, but what about `P`?\
-`P` is a closure, an **anonymous function**. As the name suggests, closures don't have a name,
-so we can't write them down in our code.
+其中 `I` 是被过滤迭代器的类型，`P` 是用于过滤元素的谓词。\
+我们知道 `I` 这里是 `std::slice::Iter<'_, Ticket>`，但 `P` 呢？\
+`P` 是个闭包，是**匿名函数 (anonymous function)**。顾名思义，闭包没有名字，所以我们没法在代码里写出来。
 
-Rust has a solution for this: **impl Trait**.
+Rust 对此有解：**`impl Trait`**。
 
 ## `impl Trait`
 
-`impl Trait` is a feature that allows you to return a type without specifying its name.
-You just declare what trait(s) the type implements, and Rust figures out the rest.
+`impl Trait` 是一项允许你返回一个类型而不必指明其名字的特性。
+你只声明该类型实现了哪些特质，剩下的由 Rust 弄清楚。
 
-In this case, we want to return an iterator of references to `Ticket`s:
+这里我们想返回一个对 `Ticket` 引用的迭代器：
 
 ```rust
 impl TicketStore {
@@ -47,23 +44,22 @@ impl TicketStore {
 }
 ```
 
-That's it!
+就这么简单！
 
-## Generic?
+## 是泛型吗？(Generic?)
 
-`impl Trait` in return position is **not** a generic parameter.
+返回位置上的 `impl Trait` **不是**泛型参数。
 
-Generics are placeholders for types that are filled in by the caller of the function.
-A function with a generic parameter is **polymorphic**: it can be called with different types, and the compiler will generate
-a different implementation for each type.
+泛型是占位符，由函数调用方填入具体类型。
+带泛型参数的函数是**多态 (polymorphic)** 的：可以用不同类型调用，编译器会为每种类型生成不同的实现。
 
-That's not the case with `impl Trait`.
-The return type of a function with `impl Trait` is **fixed** at compile time, and the compiler will generate
-a single implementation for it.
-This is why `impl Trait` is also called **opaque return type**: the caller doesn't know the exact type of the return value,
-only that it implements the specified trait(s). But the compiler knows the exact type, there is no polymorphism involved.
+`impl Trait` 不是这样的。
+带 `impl Trait` 的函数返回类型在编译期是**固定 (fixed)** 的，编译器只会为它生成一份实现。
+所以 `impl Trait` 也叫**不透明返回类型 (opaque return type)**：调用方不知道返回值的精确类型，只知道它实现了所指定的特质。但编译器知道精确类型，并不涉及多态。
 
 ## RPIT
 
-If you read RFCs or deep-dives about Rust, you might come across the acronym **RPIT**.\
-It stands for **"Return Position Impl Trait"** and refers to the use of `impl Trait` in return position.
+如果你读 RFC 或关于 Rust 的深入文章，可能会碰到缩写 **RPIT**。\
+它代表 **"Return Position Impl Trait"**，指的就是在返回位置使用 `impl Trait`。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/08_impl_trait.md)

--- a/book/src/06_ticket_management/09_impl_trait_2.md
+++ b/book/src/06_ticket_management/09_impl_trait_2.md
@@ -1,7 +1,7 @@
-# `impl Trait` in argument position
+# 参数位置上的 `impl Trait` (`impl Trait` in argument position)
 
-In the previous section, we saw how `impl Trait` can be used to return a type without specifying its name.\
-The same syntax can also be used in **argument position**:
+上一节我们看到 `impl Trait` 可以用于返回一个类型而不指明其名字。\
+同样的语法也可以用在**参数位置 (argument position)**：
 
 ```rust
 fn print_iter(iter: impl Iterator<Item = i32>) {
@@ -11,8 +11,8 @@ fn print_iter(iter: impl Iterator<Item = i32>) {
 }
 ```
 
-`print_iter` takes an iterator of `i32`s and prints each element.\
-When used in **argument position**, `impl Trait` is equivalent to a generic parameter with a trait bound:
+`print_iter` 接收一个 `i32` 的迭代器，并打印每个元素。\
+当用在**参数位置**时，`impl Trait` 等价于带特质约束的泛型参数：
 
 ```rust
 fn print_iter<T>(iter: T) 
@@ -25,8 +25,9 @@ where
 }
 ```
 
-## Downsides
+## 缺点 (Downsides)
 
-As a rule of thumb, prefer generics over `impl Trait` in argument position.\
-Generics allow the caller to explicitly specify the type of the argument, using the turbofish syntax (`::<>`),
-which can be useful for disambiguation. That's not the case with `impl Trait`.
+经验法则：在参数位置，优先使用泛型而非 `impl Trait`。\
+泛型允许调用方用 turbofish 语法 (`::<>`) 显式指定参数的类型，这对消歧很有用。`impl Trait` 不行。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/09_impl_trait_2.md)

--- a/book/src/06_ticket_management/10_slices.md
+++ b/book/src/06_ticket_management/10_slices.md
@@ -1,6 +1,6 @@
-# Slices
+# 切片 (Slices)
 
-Let's go back to the memory layout of a `Vec`:
+回到 `Vec` 的内存布局：
 
 ```rust
 let mut numbers = Vec::with_capacity(3);
@@ -21,55 +21,54 @@ Heap:  | 1 | 2 | ? |
        +---+---+---+
 ```
 
-We already remarked how `String` is just a `Vec<u8>` in disguise.\
-The similarity should prompt you to ask: "What's the equivalent of `&str` for `Vec`?"
+我们已经指出 `String` 不过是伪装的 `Vec<u8>`。\
+这个相似性应该让你提问："那 `Vec` 对应的 `&str` 是什么？"
 
 ## `&[T]`
 
-`[T]` is a **slice** of a contiguous sequence of elements of type `T`.\
-It's most commonly used in its borrowed form, `&[T]`.
+`[T]` 是元素类型为 `T` 的连续序列的**切片 (slice)**。\
+它最常以借用形式 `&[T]` 出现。
 
-There are various ways to create a slice reference from a `Vec`:
+可以用多种方式从 `Vec` 创建切片引用：
 
 ```rust
 let numbers = vec![1, 2, 3];
-// Via index syntax
+// 通过索引语法
 let slice: &[i32] = &numbers[..];
-// Via a method
+// 通过方法
 let slice: &[i32] = numbers.as_slice();
-// Or for a subset of the elements
+// 或针对元素的子集
 let slice: &[i32] = &numbers[1..];
 ```
 
-`Vec` implements the `Deref` trait using `[T]` as the target type, so you can use slice methods on a `Vec` directly
-thanks to deref coercion:
+`Vec` 实现了 `Deref` 特质，`Target` 为 `[T]`，因此借助解引用强制转换 (deref coercion) 你可以直接在 `Vec` 上调用切片方法：
 
 ```rust
 let numbers = vec![1, 2, 3];
-// Surprise, surprise: `iter` is not a method on `Vec`!
-// It's a method on `&[T]`, but you can call it on a `Vec` 
-// thanks to deref coercion.
+// 出乎意料：`iter` 不是 `Vec` 上的方法！
+// 它是 `&[T]` 上的方法，但你可以借助解引用强制转换
+// 在 `Vec` 上调用它。
 let sum: i32 = numbers.iter().sum();
 ```
 
-### Memory layout
+### 内存布局 (Memory layout)
 
-A `&[T]` is a **fat pointer**, just like `&str`.\
-It consists of a pointer to the first element of the slice and the length of the slice.
+`&[T]` 是一个**胖指针 (fat pointer)**，跟 `&str` 一样。\
+它由指向切片首元素的指针和切片长度组成。
 
-If you have a `Vec` with three elements:
+如果你有一个含三个元素的 `Vec`：
 
 ```rust
 let numbers = vec![1, 2, 3];
 ```
 
-and then create a slice reference:
+然后创建一个切片引用：
 
 ```rust
 let slice: &[i32] = &numbers[1..];
 ```
 
-you'll get this memory layout:
+会得到这样的内存布局：
 
 ```text
                   numbers                          slice
@@ -88,19 +87,20 @@ Heap:    | 1 | 2 | 3 | ? |                      |
                +--------------------------------+
 ```
 
-### `&Vec<T>` vs `&[T]`
+### `&Vec<T>` 与 `&[T]` (`&Vec<T>` vs `&[T]`)
 
-When you need to pass an immutable reference to a `Vec` to a function, prefer `&[T]` over `&Vec<T>`.\
-This allows the function to accept any kind of slice, not necessarily one backed by a `Vec`.
+当你需要把一个对 `Vec` 的不可变引用传给函数时，优先用 `&[T]` 而非 `&Vec<T>`。\
+这让函数可以接受任何切片，不一定要由 `Vec` 支撑。
 
-For example, you can then pass a subset of the elements in a `Vec`.
-But it goes further than that—you could also pass a **slice of an array**:
+例如，你可以传 `Vec` 中元素的子集。
+但还不止于此——你也可以传一个**数组的切片**：
 
 ```rust
 let array = [1, 2, 3];
 let slice: &[i32] = &array;
 ```
 
-Array slices and `Vec` slices are the same type: they're fat pointers to a contiguous sequence of elements.
-In the case of arrays, the pointer points to the stack rather than the heap, but that doesn't matter
-when it comes to using the slice.
+数组切片和 `Vec` 切片是同一个类型：它们都是指向连续元素序列的胖指针。
+对数组而言，指针指向的是栈而不是堆，但在使用切片时这无关紧要。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/10_slices.md)

--- a/book/src/06_ticket_management/11_mutable_slices.md
+++ b/book/src/06_ticket_management/11_mutable_slices.md
@@ -1,30 +1,29 @@
-# Mutable slices
+# 可变切片 (Mutable slices)
 
-Every time we've talked about slice types (like `str` and `[T]`), we've used their immutable borrow form (`&str` and `&[T]`).\
-But slices can also be mutable!
+每次我们谈到切片类型（如 `str` 和 `[T]`）时，用的都是其不可变借用形式（`&str` 和 `&[T]`）。\
+但切片也可以是可变的！
 
-Here's how you create a mutable slice:
+下面是创建可变切片的方式：
 
 ```rust
 let mut numbers = vec![1, 2, 3];
 let slice: &mut [i32] = &mut numbers;
 ```
 
-You can then modify the elements in the slice:
+然后你可以修改切片中的元素：
 
 ```rust
 slice[0] = 42;
 ```
 
-This will change the first element of the `Vec` to `42`.
+这会把 `Vec` 的第一个元素改成 `42`。
 
-## Limitations
+## 局限性 (Limitations)
 
-When working with immutable borrows, the recommendation was clear: prefer slice references over references to
-the owned type (e.g. `&[T]` over `&Vec<T>`).\
-That's **not** the case with mutable borrows.
+谈不可变借用时，建议很明确：优先用切片引用而非对所有权类型的引用（例如 `&[T]` 优于 `&Vec<T>`）。\
+对可变借用来说**不是**这样。
 
-Consider this scenario:
+考虑下面这个场景：
 
 ```rust
 let mut numbers = Vec::with_capacity(2);
@@ -32,10 +31,10 @@ let mut slice: &mut [i32] = &mut numbers;
 slice.push(1);
 ```
 
-It won't compile!\
-`push` is a method on `Vec`, not on slices. This is the manifestation of a more general principle: Rust won't
-allow you to add or remove elements from a slice. You will only be able to modify/replace the elements that are
-already there.
+这无法编译！\
+`push` 是 `Vec` 上的方法，而不是切片上的方法。这是更普遍的一条原则的体现：Rust 不允许你向切片添加或移除元素，你只能修改/替换已经存在的元素。
 
-In this regard, a `&mut Vec` or a `&mut String` are strictly more powerful than a `&mut [T]` or a `&mut str`.\
-Choose the type that best fits based on the operations you need to perform.
+在这一点上，`&mut Vec` 或 `&mut String` 严格强于 `&mut [T]` 或 `&mut str`。\
+依据你需要执行的操作选最合适的类型。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/11_mutable_slices.md)

--- a/book/src/06_ticket_management/12_two_states.md
+++ b/book/src/06_ticket_management/12_two_states.md
@@ -1,7 +1,7 @@
-# Ticket ids
+# 工单 id (Ticket ids)
 
-Let's think again about our ticket management system.\
-Our ticket model right now looks like this:
+让我们再思考一下我们的工单管理系统。\
+当前我们的工单模型是这样：
 
 ```rust
 pub struct Ticket {
@@ -11,14 +11,13 @@ pub struct Ticket {
 }
 ```
 
-One thing is missing here: an **identifier** to uniquely identify a ticket.\
-That identifier should be unique for each ticket. That can be guaranteed by generating it automatically when
-a new ticket is created.
+这里漏了一样东西：用来唯一标识工单的**标识符 (identifier)**。\
+该标识符对每张工单都应当唯一。这点可以通过在新工单创建时自动生成来保证。
 
-## Refining the model
+## 细化模型 (Refining the model)
 
-Where should the id be stored?\
-We could add a new field to the `Ticket` struct:
+id 应当存放在哪里？\
+我们可以给 `Ticket` 结构体加一个新字段：
 
 ```rust
 pub struct Ticket {
@@ -29,8 +28,8 @@ pub struct Ticket {
 }
 ```
 
-But we don't know the id before creating the ticket. So it can't be there from the get-go.\
-It'd have to be optional:
+但在创建工单之前我们并不知道 id，所以它不能从一开始就在那。\
+那它必须是可选的：
 
 ```rust
 pub struct Ticket {
@@ -41,11 +40,9 @@ pub struct Ticket {
 }
 ```
 
-That's also not ideal—we'd have to handle the `None` case every single time we retrieve a ticket from the store,
-even though we know that the id should always be there once the ticket has been created.
+这也不理想——每次从存储中取出工单时都要处理 `None` 情况，尽管我们知道工单创建之后 id 总应当存在。
 
-The best solution is to have two different ticket **states**, represented by two separate types:
-a `TicketDraft` and a `Ticket`:
+最好的方案是：用两种独立的类型表示工单的两种**状态 (state)**——`TicketDraft` 和 `Ticket`：
 
 ```rust
 pub struct TicketDraft {
@@ -61,7 +58,8 @@ pub struct Ticket {
 }
 ```
 
-A `TicketDraft` is a ticket that hasn't been created yet. It doesn't have an id, and it doesn't have a status.\
-A `Ticket` is a ticket that has been created. It has an id and a status.\
-Since each field in `TicketDraft` and `Ticket` embeds its own constraints, we don't have to duplicate logic
-across the two types.
+`TicketDraft` 是尚未创建的工单。它没有 id，也没有状态。\
+`Ticket` 是已创建的工单。它有 id 和状态。\
+由于 `TicketDraft` 和 `Ticket` 中每个字段都内嵌了自己的约束，我们不需要在两个类型间复制逻辑。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/12_two_states.md)

--- a/book/src/06_ticket_management/13_index.md
+++ b/book/src/06_ticket_management/13_index.md
@@ -1,37 +1,36 @@
-# Indexing
+# 索引 (Indexing)
 
-`TicketStore::get` returns an `Option<&Ticket>` for a given `TicketId`.\
-We've seen before how to access elements of arrays and vectors using Rust's
-indexing syntax:
+`TicketStore::get` 接受一个 `TicketId` 并返回 `Option<&Ticket>`。\
+我们之前见过怎么用 Rust 的索引语法访问数组和向量的元素：
 
 ```rust
 let v = vec![0, 1, 2];
 assert_eq!(v[0], 0);
 ```
 
-How can we provide the same experience for `TicketStore`?\
-You guessed right: we need to implement a trait, `Index`!
+我们怎么为 `TicketStore` 提供同样的体验？\
+你猜对了：我们要实现一个特质——`Index`！
 
 ## `Index`
 
-The `Index` trait is defined in Rust's standard library:
+`Index` 特质定义在 Rust 标准库中：
 
 ```rust
-// Slightly simplified
+// 略简化
 pub trait Index<Idx>
 {
     type Output;
 
-    // Required method
+    // 必须实现的方法
     fn index(&self, index: Idx) -> &Self::Output;
 }
 ```
 
-It has:
+它有：
 
-- One generic parameter, `Idx`, to represent the index type
-- One associated type, `Output`, to represent the type we retrieved using the index
+- 一个泛型参数 `Idx`，用于表示索引类型
+- 一个关联类型 `Output`，表示通过索引获取到的值的类型
 
-Notice how the `index` method doesn't return an `Option`. The assumption is that
-`index` will panic if you try to access an element that's not there, as it happens
-for array and vec indexing.
+注意 `index` 方法不返回 `Option`。预设是：当你尝试访问不存在的元素时 `index` 会 panic，跟数组和 vec 的索引一样。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/13_index.md)

--- a/book/src/06_ticket_management/14_index_mut.md
+++ b/book/src/06_ticket_management/14_index_mut.md
@@ -1,20 +1,20 @@
-# Mutable indexing
+# 可变索引 (Mutable indexing)
 
-`Index` allows read-only access. It doesn't let you mutate the value you
-retrieved.
+`Index` 只允许只读访问，不允许你修改取出的值。
 
 ## `IndexMut`
 
-If you want to allow mutability, you need to implement the `IndexMut` trait.
+如果你想允许可变性，需要实现 `IndexMut` 特质。
 
 ```rust
-// Slightly simplified
+// 略简化
 pub trait IndexMut<Idx>: Index<Idx>
 {
-    // Required method
+    // 必须实现的方法
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output;
 }
 ```
 
-`IndexMut` can only be implemented if the type already implements `Index`,
-since it unlocks an _additional_ capability.
+`IndexMut` 只能在类型已经实现了 `Index` 的前提下实现，因为它解锁的是一项 _额外_ 能力。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/14_index_mut.md)

--- a/book/src/06_ticket_management/15_hashmap.md
+++ b/book/src/06_ticket_management/15_hashmap.md
@@ -1,16 +1,14 @@
 # `HashMap`
 
-Our implementation of `Index`/`IndexMut` is not ideal: we need to iterate over the entire
-`Vec` to retrieve a ticket by id; the algorithmic complexity is `O(n)`, where
-`n` is the number of tickets in the store.
+我们的 `Index`/`IndexMut` 实现并不理想：要按 id 取出工单需要遍历整个 `Vec`；算法复杂度是 `O(n)`，其中 `n` 是 store 中工单的数量。
 
-We can do better by using a different data structure for storing tickets: a `HashMap<K, V>`.
+我们可以通过用不同的数据结构存储工单来做得更好：`HashMap<K, V>`。
 
 ```rust
 use std::collections::HashMap;
 
-// Type inference lets us omit an explicit type signature (which
-// would be `HashMap<String, String>` in this example).
+// 类型推断让我们可以省略显式类型签名
+//（这个例子里会是 `HashMap<String, String>`）。
 let mut book_reviews = HashMap::new();
 
 book_reviews.insert(
@@ -19,19 +17,17 @@ book_reviews.insert(
 );
 ```
 
-`HashMap` works with key-value pairs. It's generic over both: `K` is the generic
-parameter for the key type, while `V` is the one for the value type.
+`HashMap` 处理键值对 (key-value pair)。它对二者都是泛型的：`K` 是键类型的泛型参数，`V` 是值类型的泛型参数。
 
-The expected cost of insertions, retrievals and removals is **constant**, `O(1)`.
-That sounds perfect for our usecase, doesn't it?
+插入、查询和删除的预期成本都是**常数级**的，`O(1)`。
+听起来正合我们的需求，是不是？
 
-## Key requirements
+## 键的要求 (Key requirements)
 
-There are no trait bounds on `HashMap`'s struct definition, but you'll find some
-on its methods. Let's look at `insert`, for example:
+`HashMap` 结构体定义本身没有特质约束，但它的方法上有。我们看看 `insert`：
 
 ```rust
-// Slightly simplified
+// 略简化
 impl<K, V> HashMap<K, V>
 where
     K: Eq + Hash,
@@ -42,31 +38,29 @@ where
 }
 ```
 
-The key type must implement the `Eq` and `Hash` traits.\
-Let's dig into those two.
+键类型必须实现 `Eq` 和 `Hash` 特质。\
+我们一一深入。
 
 ## `Hash`
 
-A hashing function (or hasher) maps a potentially infinite set of a values (e.g.
-all possible strings) to a bounded range (e.g. a `u64` value).\
-There are many different hashing functions around, each with different properties
-(speed, collision risk, reversibility, etc.).
+哈希函数（hashing function 或 hasher）把可能无穷的值集合（例如所有可能的字符串）映射到有界范围（例如一个 `u64` 值）。\
+有许多不同的哈希函数，各有不同特性（速度、碰撞风险、可逆性等）。
 
-A `HashMap`, as the name suggests, uses a hashing function behind the scene.
-It hashes your key and then uses that hash to store/retrieve the associated value.
-This strategy requires the key type must be hashable, hence the `Hash` trait bound on `K`.
+`HashMap`，顾名思义，幕后使用了哈希函数。
+它对你的键做哈希，再用这个哈希值来存储/检索关联值。
+这种策略要求键类型必须可哈希，因此 `K` 上有 `Hash` 特质约束。
 
-You can find the `Hash` trait in the `std::hash` module:
+`Hash` 特质位于 `std::hash` 模块下：
 
 ```rust
 pub trait Hash {
-    // Required method
+    // 必须实现的方法
     fn hash<H>(&self, state: &mut H)
        where H: Hasher;
 }
 ```
 
-You will rarely implement `Hash` manually. Most of the times you'll derive it:
+你很少需要手动实现 `Hash`。大多数情况下你会派生它：
 
 ```rust
 #[derive(Hash)]
@@ -78,28 +72,24 @@ struct Person {
 
 ## `Eq`
 
-`HashMap` must be able to compare keys for equality. This is particularly important
-when dealing with hash collisions—i.e. when two different keys hash to the same value.
+`HashMap` 必须能比较键的相等性。这在处理哈希碰撞 (hash collision) 时尤其重要——即两个不同的键被哈希到同一个值。
 
-You may wonder: isn't that what the `PartialEq` trait is for? Almost!\
-`PartialEq` is not enough for `HashMap` because it doesn't guarantee reflexivity, i.e. `a == a` is always `true`.\
-For example, floating point numbers (`f32` and `f64`) implement `PartialEq`,
-but they don't satisfy the reflexivity property: `f32::NAN == f32::NAN` is `false`.\
-Reflexivity is crucial for `HashMap` to work correctly: without it, you wouldn't be able to retrieve a value
-from the map using the same key you used to insert it.
+你可能想：这不就是 `PartialEq` 吗？几乎是！\
+对 `HashMap` 来说 `PartialEq` 不够，因为它不保证自反性 (reflexivity)，即 `a == a` 总为 `true`。\
+例如，浮点数 (`f32` 和 `f64`) 实现了 `PartialEq`，但不满足自反性：`f32::NAN == f32::NAN` 是 `false`。\
+对 `HashMap` 正确工作来说自反性至关重要：没有它，你就无法使用插入时使用的同一个键再从 map 中取回值。
 
-The `Eq` trait extends `PartialEq` with the reflexivity property:
+`Eq` 特质在 `PartialEq` 之上加了自反性属性：
 
 ```rust
 pub trait Eq: PartialEq {
-    // No additional methods
+    // 没有附加方法
 }
 ```
 
-It's a marker trait: it doesn't add any new methods, it's just a way for you to say to the compiler
-that the equality logic implemented in `PartialEq` is reflexive.
+它是个标记特质 (marker trait)：不引入新方法，只是让你向编译器声明 `PartialEq` 中实现的相等逻辑是自反的。
 
-You can derive `Eq` automatically when you derive `PartialEq`:
+派生 `PartialEq` 时可以一并自动派生 `Eq`：
 
 ```rust
 #[derive(PartialEq, Eq)]
@@ -109,8 +99,9 @@ struct Person {
 }
 ```
 
-## `Eq` and `Hash` are linked
+## `Eq` 与 `Hash` 是关联的 (`Eq` and `Hash` are linked)
 
-There is an implicit contract between `Eq` and `Hash`: if two keys are equal, their hashes must be equal too.
-This is crucial for `HashMap` to work correctly. If you break this contract, you'll get nonsensical results
-when using `HashMap`.
+`Eq` 与 `Hash` 之间有一条隐式契约：如果两个键相等，它们的哈希值也必须相等。
+这对 `HashMap` 正确工作至关重要。如果你违反这条契约，使用 `HashMap` 时就会得到没意义的结果。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/15_hashmap.md)

--- a/book/src/06_ticket_management/16_btreemap.md
+++ b/book/src/06_ticket_management/16_btreemap.md
@@ -1,43 +1,40 @@
-# Ordering
+# 排序 (Ordering)
 
-By moving from a `Vec` to a `HashMap` we have improved the performance of our ticket management system,
-and simplified our code in the process.\
-It's not all roses, though. When iterating over a `Vec`-backed store, we could be sure that the tickets
-would be returned in the order they were added.\
-That's not the case with a `HashMap`: you can iterate over the tickets, but the order is random.
+通过把 `Vec` 换成 `HashMap`，我们提升了工单管理系统的性能，过程中还简化了代码。\
+但并非全是好处。在以 `Vec` 为底层的 store 上迭代时，我们能确定工单按添加顺序返回。\
+`HashMap` 不是这样：你可以遍历工单，但顺序是随机的。
 
-We can recover a consistent ordering by switching from a `HashMap` to a `BTreeMap`.
+我们可以通过把 `HashMap` 换成 `BTreeMap` 来恢复一致顺序。
 
 ## `BTreeMap`
 
-A `BTreeMap` guarantees that entries are sorted by their keys.\
-This is useful when you need to iterate over the entries in a specific order, or if you need to
-perform range queries (e.g. "give me all tickets with an id between 10 and 20").
+`BTreeMap` 保证条目按键排序。\
+当你需要按特定顺序遍历条目，或需要做范围查询（例如"给我所有 id 在 10 到 20 之间的工单"）时，这很有用。
 
-Just like `HashMap`, you won't find trait bounds on the definition of `BTreeMap`.
-But you'll find trait bounds on its methods. Let's look at `insert`:
+跟 `HashMap` 一样，`BTreeMap` 的定义上没有特质约束，
+但其方法上有。我们看看 `insert`：
 
 ```rust
-// `K` and `V` stand for the key and value types, respectively,
-// just like in `HashMap`.
+// `K` 和 `V` 分别表示键和值的类型，
+// 跟 `HashMap` 一样。
 impl<K, V> BTreeMap<K, V> {
     pub fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord,
     {
-        // implementation
+        // 实现
     }
 }
 ```
 
-`Hash` is no longer required. Instead, the key type must implement the `Ord` trait.
+`Hash` 不再是必须的。取而代之，键类型必须实现 `Ord` 特质。
 
 ## `Ord`
 
-The `Ord` trait is used to compare values.\
-While `PartialEq` is used to compare for equality, `Ord` is used to compare for ordering.
+`Ord` 特质用来比较值。\
+`PartialEq` 用来比较相等性，`Ord` 用来比较顺序。
 
-It's defined in `std::cmp`:
+它定义在 `std::cmp` 中：
 
 ```rust
 pub trait Ord: Eq + PartialOrd {
@@ -45,14 +42,13 @@ pub trait Ord: Eq + PartialOrd {
 }
 ```
 
-The `cmp` method returns an `Ordering` enum, which can be one
-of `Less`, `Equal`, or `Greater`.\
-`Ord` requires that two other traits are implemented: `Eq` and `PartialOrd`.
+`cmp` 方法返回 `Ordering` 枚举，其值可能是 `Less`、`Equal` 或 `Greater`。\
+`Ord` 要求另两个特质也已实现：`Eq` 与 `PartialOrd`。
 
 ## `PartialOrd`
 
-`PartialOrd` is a weaker version of `Ord`, just like `PartialEq` is a weaker version of `Eq`.
-You can see why by looking at its definition:
+`PartialOrd` 是 `Ord` 的较弱版本，正如 `PartialEq` 是 `Eq` 的较弱版本。
+看看它的定义就明白了：
 
 ```rust
 pub trait PartialOrd: PartialEq {
@@ -60,23 +56,23 @@ pub trait PartialOrd: PartialEq {
 }
 ```
 
-`PartialOrd::partial_cmp` returns an `Option`—it is not guaranteed that two values can
-be compared.\
-For example, `f32` doesn't implement `Ord` because `NaN` values are not comparable,
-the same reason why `f32` doesn't implement `Eq`.
+`PartialOrd::partial_cmp` 返回 `Option`——并不能保证两个值之间一定可比较。\
+例如 `f32` 不实现 `Ord`，因为 `NaN` 值不可比较；同样的原因 `f32` 也不实现 `Eq`。
 
-## Implementing `Ord` and `PartialOrd`
+## 实现 `Ord` 与 `PartialOrd` (Implementing `Ord` and `PartialOrd`)
 
-Both `Ord` and `PartialOrd` can be derived for your types:
+`Ord` 与 `PartialOrd` 都可以为你的类型派生：
 
 ```rust
-// You need to add `Eq` and `PartialEq` too,
-// since `Ord` requires them.
+// 你也得加上 `Eq` 和 `PartialEq`，
+// 因为 `Ord` 要求它们。
 #[derive(Eq, PartialEq, Ord, PartialOrd)]
 struct TicketId(u64);
 ```
 
-If you choose (or need) to implement them manually, be careful:
+如果你选择（或必须）手动实现，要小心：
 
-- `Ord` and `PartialOrd` must be consistent with `Eq` and `PartialEq`.
-- `Ord` and `PartialOrd` must be consistent with each other.
+- `Ord` 与 `PartialOrd` 必须与 `Eq` 和 `PartialEq` 一致。
+- `Ord` 与 `PartialOrd` 必须彼此一致。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/06_ticket_management/16_btreemap.md)


### PR DESCRIPTION
## Summary

进度：58/100 → 75/100（+17）

第 6 章全章翻译：数组 / Vec / 调整大小 / 迭代器 / IntoIterator / .iter() / 生命周期 / 组合子+闭包 / impl Trait（返回与参数位置）/ 切片 / 可变切片 / 两状态建模 / Index / IndexMut / HashMap+Eq+Hash / BTreeMap+Ord+PartialOrd。

同步更新 README checklist 与 welcome.md 进度数。

https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA)_