### PR TITLE
翻译: 第 7 章 线程 Threads（15 篇）

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,21 +145,21 @@
 - [x] ✅ 06_ticket_management/16_btreemap.md
 
 ### 第7章：线程 (Threads)
-- [ ] ⏸️ 07_threads/00_intro.md
-- [ ] ⏸️ 07_threads/01_threads.md
-- [ ] ⏸️ 07_threads/02_static.md
-- [ ] ⏸️ 07_threads/03_leak.md
-- [ ] ⏸️ 07_threads/04_scoped_threads.md
-- [ ] ⏸️ 07_threads/05_channels.md
-- [ ] ⏸️ 07_threads/06_interior_mutability.md
-- [ ] ⏸️ 07_threads/07_ack.md
-- [ ] ⏸️ 07_threads/08_client.md
-- [ ] ⏸️ 07_threads/09_bounded.md
-- [ ] ⏸️ 07_threads/10_patch.md
-- [ ] ⏸️ 07_threads/11_locks.md
-- [ ] ⏸️ 07_threads/12_rw_lock.md
-- [ ] ⏸️ 07_threads/13_without_channels.md
-- [ ] ⏸️ 07_threads/14_sync.md
+- [x] ✅ 07_threads/00_intro.md
+- [x] ✅ 07_threads/01_threads.md
+- [x] ✅ 07_threads/02_static.md
+- [x] ✅ 07_threads/03_leak.md
+- [x] ✅ 07_threads/04_scoped_threads.md
+- [x] ✅ 07_threads/05_channels.md
+- [x] ✅ 07_threads/06_interior_mutability.md
+- [x] ✅ 07_threads/07_ack.md
+- [x] ✅ 07_threads/08_client.md
+- [x] ✅ 07_threads/09_bounded.md
+- [x] ✅ 07_threads/10_patch.md
+- [x] ✅ 07_threads/11_locks.md
+- [x] ✅ 07_threads/12_rw_lock.md
+- [x] ✅ 07_threads/13_without_channels.md
+- [x] ✅ 07_threads/14_sync.md
 
 ### 第8章：Futures (异步编程)
 - [ ] ⏸️ 08_futures/00_intro.md

--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -1,7 +1,7 @@
 # 欢迎
 
 > 🌏 **中文版说明**
-> 本书正在翻译中，当前进度约 75%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
+> 本书正在翻译中，当前进度约 90%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
 > 英文原版请访问 [rust-exercises.com](https://rust-exercises.com)。
 > 翻译问题请提交到 [GitHub Issues](https://github.com/tangivis/100-exercises-to-learn-rust/issues)。
 

--- a/book/src/07_threads/00_intro.md
+++ b/book/src/07_threads/00_intro.md
@@ -1,15 +1,17 @@
-# Intro
+# 引入 (Intro)
 
-One of Rust's big promises is _fearless concurrency_: making it easier to write safe, concurrent programs.
-We haven't seen much of that yet. All the work we've done so far has been single-threaded.
-Time to change that!
+Rust 的一大承诺是 _无畏并发 (fearless concurrency)_：让安全的并发程序更易编写。
+我们到目前为止还没怎么见到这点——所有工作都是单线程的。
+是时候改变这个状况了！
 
-In this chapter we'll make our ticket store multithreaded.\
-We'll have the opportunity to touch most of Rust's core concurrency features, including:
+本章我们要把工单存储改成多线程。\
+我们会有机会接触到 Rust 大部分核心并发特性，包括：
 
-- Threads, using the `std::thread` module
-- Message passing, using channels
-- Shared state, using `Arc`, `Mutex` and `RwLock`
-- `Send` and `Sync`, the traits that encode Rust's concurrency guarantees
+- 线程，使用 `std::thread` 模块
+- 消息传递 (message passing)，使用通道 (channel)
+- 共享状态 (shared state)，使用 `Arc`、`Mutex` 与 `RwLock`
+- `Send` 与 `Sync`，编码 Rust 并发保证的特质
 
-We'll also discuss various design patterns for multithreaded systems and some of their trade-offs.
+我们也会讨论多线程系统的若干设计模式及其取舍。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/00_intro.md)

--- a/book/src/07_threads/01_threads.md
+++ b/book/src/07_threads/01_threads.md
@@ -1,27 +1,22 @@
-# Threads
+# 线程 (Threads)
 
-Before we start writing multithreaded code, let's take a step back and talk about what threads are
-and why we might want to use them.
+在我们开始写多线程代码之前，先退一步谈谈线程是什么、我们为什么要用它。
 
-## What is a thread?
+## 什么是线程？(What is a thread?)
 
-A **thread** is an execution context managed by the underlying operating system.\
-Each thread has its own stack and instruction pointer.
+**线程 (thread)** 是由底层操作系统管理的执行上下文。\
+每个线程有自己的栈和指令指针 (instruction pointer)。
 
-A single **process** can manage multiple threads.
-These threads share the same memory space, which means they can access the same data.
+一个**进程 (process)** 可以管理多个线程。
+这些线程共享同一片内存空间，意味着它们可以访问同样的数据。
 
-Threads are a **logical** construct. In the end, you can only run one set of instructions
-at a time on a CPU core, the **physical** execution unit.\
-Since there can be many more threads than there are CPU cores, the operating system's
-**scheduler** is in charge of deciding which thread to run at any given time,
-partitioning CPU time among them to maximize throughput and responsiveness.
+线程是**逻辑 (logical)** 构造。最终，CPU 核心（**物理 (physical)** 执行单元）一次只能运行一组指令。\
+由于线程数可能远多于 CPU 核心数，操作系统的**调度器 (scheduler)** 负责决定在任意时刻运行哪个线程，把 CPU 时间在它们之间划分以最大化吞吐量和响应性。
 
 ## `main`
 
-When a Rust program starts, it runs on a single thread, the **main thread**.\
-This thread is created by the operating system and is responsible for running the `main`
-function.
+Rust 程序启动时，运行在单个线程上——**主线程 (main thread)**。\
+这个线程由操作系统创建，负责运行 `main` 函数。
 
 ```rust
 use std::thread;
@@ -37,14 +32,13 @@ fn main() {
 
 ## `std::thread`
 
-Rust's standard library provides a module, `std::thread`, that allows you to create
-and manage threads.
+Rust 标准库提供了 `std::thread` 模块，允许你创建和管理线程。
 
 ### `spawn`
 
-You can use `std::thread::spawn` to create new threads and execute code on them.
+可以用 `std::thread::spawn` 创建新线程并在其上执行代码。
 
-For example:
+例如：
 
 ```rust
 use std::thread;
@@ -65,14 +59,13 @@ fn main() {
 }
 ```
 
-If you execute this program on the [Rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=afedf7062298ca8f5a248bc551062eaa)
-you'll see that the main thread and the spawned thread run concurrently.\
-Each thread makes progress independently of the other.
+如果你在 [Rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=afedf7062298ca8f5a248bc551062eaa) 上执行这段程序，
+你会看到主线程和被 spawn 出来的线程并发运行，各自独立地推进。
 
-### Process termination
+### 进程终止 (Process termination)
 
-When the main thread finishes, the overall process will exit.\
-A spawned thread will continue running until it finishes or the main thread finishes.
+主线程结束时，整个进程也会退出。\
+被 spawn 的线程会一直运行，直到它自己结束或主线程结束。
 
 ```rust
 use std::thread;
@@ -90,13 +83,12 @@ fn main() {
 }
 ```
 
-In the example above, you can expect to see the message "Hello from a thread!" printed roughly five times.\
-Then the main thread will finish (when the `sleep` call returns), and the spawned thread will be terminated
-since the overall process exits.
+上面的例子中，你应当能看到 "Hello from a thread!" 大约被打印 5 次。\
+然后主线程结束（`sleep` 调用返回时），而被 spawn 的线程也会因为整个进程退出而被终止。
 
 ### `join`
 
-You can also wait for a spawned thread to finish by calling the `join` method on the `JoinHandle` that `spawn` returns.
+你也可以通过对 `spawn` 返回的 `JoinHandle` 调用 `join` 方法来等待 spawn 的线程结束。
 
 ```rust
 use std::thread;
@@ -109,7 +101,7 @@ fn main() {
 }
 ```
 
-In this example, the main thread will wait for the spawned thread to finish before exiting.\
-This introduces a form of **synchronization** between the two threads: you're guaranteed to see the message
-"Hello from a thread!" printed before the program exits, because the main thread won't exit
-until the spawned thread has finished.
+这个例子里，主线程会等被 spawn 的线程完成后再退出。\
+这就在两个线程之间引入了一种**同步 (synchronization)** 形式：你可以确保程序退出之前一定能看到 "Hello from a thread!"，因为主线程要等到被 spawn 的线程结束才会退出。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/01_threads.md)

--- a/book/src/07_threads/02_static.md
+++ b/book/src/07_threads/02_static.md
@@ -1,7 +1,7 @@
 # `'static`
 
-If you tried to borrow a slice from the vector in the previous exercise,
-you probably got a compiler error that looks something like this:
+如果你尝试在前一个练习里从向量借用一个切片，
+你大概会得到一条这样的编译错误：
 
 ```text
 error[E0597]: `v` does not live long enough
@@ -18,15 +18,15 @@ error[E0597]: `v` does not live long enough
    |  - `v` dropped here while still borrowed
 ```
 
-`argument requires that v is borrowed for 'static`, what does that mean?
+`argument requires that v is borrowed for 'static`，这是什么意思？
 
-The `'static` lifetime is a special lifetime in Rust.\
-It means that the value will be valid for the entire duration of the program.
+`'static` 生命周期是 Rust 中一个特殊的生命周期。\
+它意味着该值在程序的整个运行期内都有效。
 
-## Detached threads
+## 分离的线程 (Detached threads)
 
-A thread launched via `thread::spawn` can **outlive** the thread that spawned it.\
-For example:
+通过 `thread::spawn` 启动的线程可以**比 (outlive) 它的父线程更长寿**。\
+例如：
 
 ```rust
 use std::thread;
@@ -43,25 +43,21 @@ fn f() {
 }
 ```
 
-In this example, the first spawned thread will in turn spawn
-a child thread that prints a message every second.\
-The first thread will then finish and exit. When that happens,
-its child thread will **continue running** for as long as the
-overall process is running.\
-In Rust's lingo, we say that the child thread has **outlived**
-its parent.
+这个例子里，第一个被 spawn 的线程又 spawn 了一个子线程，子线程每秒打印一条消息。\
+第一个线程随后完成并退出。当这发生时，
+其子线程会**继续运行**，只要整个进程还在运行。\
+用 Rust 的术语说，子线程**比 (outlived)** 它的父线程更长寿。
 
-## `'static` lifetime
+## `'static` 生命周期 (`'static` lifetime)
 
-Since a spawned thread can:
+由于 spawn 的线程可能：
 
-- outlive the thread that spawned it (its parent thread)
-- run until the program exits
+- 比 spawn 它的线程（父线程）更长寿
+- 一直运行到程序退出
 
-it must not borrow any values that might be dropped before the program exits;
-violating this constraint would expose us to a use-after-free bug.\
-That's why `std::thread::spawn`'s signature requires that the closure passed to it
-has the `'static` lifetime:
+它必须不能借用任何可能在程序退出之前被丢弃的值；
+违反这个约束会让我们暴露在 use-after-free bug 之下。\
+这就是为什么 `std::thread::spawn` 的签名要求传给它的闭包具有 `'static` 生命周期：
 
 ```rust
 pub fn spawn<F, T>(f: F) -> JoinHandle<T> 
@@ -73,42 +69,38 @@ where
 }
 ```
 
-## `'static` is not (just) about references
+## `'static` 不（仅仅）关乎引用 (`'static` is not (just) about references)
 
-All values in Rust have a lifetime, not just references.
+Rust 中所有值都有生命周期，不只是引用。
 
-In particular, a type that owns its data (like a `Vec` or a `String`)
-satisfies the `'static` constraint: if you own it, you can keep working with it
-for as long as you want, even after the function that originally created it
-has returned.
+特别地，一个拥有自己数据的类型（例如 `Vec` 或 `String`）满足 `'static` 约束：如果你拥有它，你想用多久都行，即使最初创建它的函数已经返回了。
 
-You can thus interpret `'static` as a way to say:
+因此你可以把 `'static` 解读为：
 
-- Give me an owned value
-- Give me a reference that's valid for the entire duration of the program
+- 给我一个具有所有权的值
+- 给我一个在程序整个运行期内都有效的引用
 
-The first approach is how you solved the issue in the previous exercise:
-by allocating new vectors to hold the left and right parts of the original vector,
-which were then moved into the spawned threads.
+第一种方式正是你在前一个练习里解决问题的方式：
+分配新的向量来分别持有原向量的左半段和右半段，再把它们移入 (move) 被 spawn 的线程。
 
-## `'static` references
+## `'static` 引用 (`'static` references)
 
-Let's talk about the second case, references that are valid for the entire
-duration of the program.
+我们来谈第二种情况：在程序整个运行期内都有效的引用。
 
-### Static data
+### 静态数据 (Static data)
 
-The most common case is a reference to **static data**, such as string literals:
+最常见的情形是对**静态数据 (static data)** 的引用，比如字符串字面量：
 
 ```rust
 let s: &'static str = "Hello world!";
 ```
 
-Since string literals are known at compile-time, Rust stores them _inside_ your executable,
-in a region known as **read-only data segment**.
-All references pointing to that region will therefore be valid for as long as
-the program runs; they satisfy the `'static` contract.
+由于字符串字面量在编译期已知，Rust 把它们存放在你的可执行文件 _内部_，
+位于一个叫**只读数据段 (read-only data segment)** 的区域。
+所有指向该区域的引用因此在整个程序运行期内都有效；它们满足 `'static` 契约。
 
-## Further reading
+## 进一步阅读
 
 - [The data segment](https://en.wikipedia.org/wiki/Data_segment)
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/02_static.md)

--- a/book/src/07_threads/03_leak.md
+++ b/book/src/07_threads/03_leak.md
@@ -1,29 +1,26 @@
-# Leaking data
+# 泄漏数据 (Leaking data)
 
-The main concern around passing references to spawned threads is use-after-free bugs:
-accessing data using a pointer to a memory region that's already been freed/de-allocated.\
-If you're working with heap-allocated data, you can avoid the issue by
-telling Rust that you'll never reclaim that memory: you choose to **leak memory**,
-intentionally.
+把引用传给 spawn 的线程的主要顾虑是 use-after-free bug：
+通过指向已经被释放/回收内存区域的指针来访问数据。\
+如果你处理的是堆分配的数据，可以告诉 Rust 你永远不会回收那块内存来避开这个问题：你刻意选择**泄漏内存 (leak memory)**。
 
-This can be done, for example, using the `Box::leak` method from Rust's standard library:
+可以用 Rust 标准库里的 `Box::leak` 方法做到这点：
 
 ```rust
-// Allocate a `u32` on the heap, by wrapping it in a `Box`.
+// 通过把 `u32` 包到 `Box` 里来在堆上分配它。
 let x = Box::new(41u32);
-// Tell Rust that you'll never free that heap allocation
-// using `Box::leak`. You can thus get back a 'static reference.
+// 用 `Box::leak` 告诉 Rust 你永远不会释放这块堆分配。
+// 你因此能拿回一个 'static 引用。
 let static_ref: &'static mut u32 = Box::leak(x);
 ```
 
-## Data leakage is process-scoped
+## 数据泄漏是进程级的 (Data leakage is process-scoped)
 
-Leaking data is dangerous: if you keep leaking memory, you'll eventually
-run out and crash with an out-of-memory error.
+泄漏数据是危险的：如果你不停泄漏内存，最终会用尽内存并以"内存不足 (out-of-memory)" 错误崩溃。
 
 ```rust
-// If you leave this running for a while, 
-// it'll eventually use all the available memory.
+// 如果你让它跑一阵子，
+// 它最终会用光所有可用内存。
 fn oom_trigger() {
     loop {
         let v: Vec<usize> = Vec::with_capacity(1024);
@@ -32,15 +29,15 @@ fn oom_trigger() {
 }
 ```
 
-At the same time, memory leaked via `leak` method is not truly forgotten.\
-The operating system can map each memory region to the process responsible for it.
-When the process exits, the operating system will reclaim that memory.
+同时，通过 `leak` 方法泄漏的内存并未真正被遗忘。\
+操作系统能把每块内存区域映射到负责它的进程。
+进程退出时，操作系统会回收那块内存。
 
-Keeping this in mind, it can be OK to leak memory when:
+记住这点的话，泄漏内存在以下情形是可以接受的：
 
-- The amount of memory you need to leak is bounded/known upfront, or
-- Your process is short-lived and you're confident you won't exhaust
-  all the available memory before it exits
+- 需要泄漏的内存量是有界 (bounded)/事先已知的，或者
+- 你的进程是短生命周期的，且你确信在它退出之前不会耗尽所有可用内存
 
-"Let the OS deal with it" is a perfectly valid memory management strategy
-if your usecase allows for it.
+如果你的用例允许，"让 OS 处理它"是一种完全有效的内存管理策略。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/03_leak.md)

--- a/book/src/07_threads/04_scoped_threads.md
+++ b/book/src/07_threads/04_scoped_threads.md
@@ -1,8 +1,8 @@
-# Scoped threads
+# 作用域线程 (Scoped threads)
 
-All the lifetime issues we discussed so far have a common source:
-the spawned thread can outlive its parent.\
-We can sidestep this issue by using **scoped threads**.
+我们到目前为止讨论的所有生命周期问题都有一个共同根源：
+被 spawn 的线程可能比父线程更长寿。\
+我们可以通过使用**作用域线程 (scoped threads)** 绕开这个问题。
 
 ```rust
 let v = vec![1, 2, 3];
@@ -22,21 +22,19 @@ std::thread::scope(|scope| {
 println!("Here's v: {v:?}");
 ```
 
-Let's unpack what's happening.
+我们逐步拆解发生了什么。
 
 ## `scope`
 
-The `std::thread::scope` function creates a new **scope**.\
-`std::thread::scope` takes a closure as input, with a single argument: a `Scope` instance.
+`std::thread::scope` 函数创建一个新的**作用域 (scope)**。\
+`std::thread::scope` 接受一个闭包作为输入，闭包带一个参数：`Scope` 实例。
 
-## Scoped spawns
+## 作用域内的 spawn (Scoped spawns)
 
-`Scope` exposes a `spawn` method.\
-Unlike `std::thread::spawn`, all threads spawned using a `Scope` will be
-**automatically joined** when the scope ends.
+`Scope` 暴露了一个 `spawn` 方法。\
+跟 `std::thread::spawn` 不同，所有通过 `Scope` spawn 的线程在作用域结束时都会**自动 join**。
 
-If we were to "translate" the previous example to `std::thread::spawn`,
-it'd look like this:
+如果我们把前面的例子"翻译"成 `std::thread::spawn`，会是这样：
 
 ```rust
 let v = vec![1, 2, 3];
@@ -57,17 +55,15 @@ handle2.join().unwrap();
 println!("Here's v: {v:?}");
 ```
 
-## Borrowing from the environment
+## 从环境借用 (Borrowing from the environment)
 
-The translated example wouldn't compile, though: the compiler would complain
-that `&v` can't be used from our spawned threads since its lifetime isn't
-`'static`.
+不过翻译过来的版本不会通过编译：编译器会抱怨 `&v` 不能从被 spawn 的线程里使用，因为它的生命周期不是 `'static`。
 
-That's not an issue with `std::thread::scope`—you can **safely borrow from the environment**.
+`std::thread::scope` 没有这个问题——你可以**安全地从环境借用 (safely borrow from the environment)**。
 
-In our example, `v` is created before the spawning points.
-It will only be dropped _after_ `scope` returns. At the same time,
-all threads spawned inside `scope` are guaranteed to finish _before_ `scope` returns,
-therefore there is no risk of having dangling references.
+我们的例子里，`v` 在 spawn 之前就创建了。
+它要在 `scope` 返回 _之后_ 才被丢弃。同时，所有在 `scope` 内 spawn 的线程都保证在 `scope` 返回 _之前_ 完成，因此不存在悬垂引用的风险。
 
-The compiler won't complain!
+编译器不会抱怨！
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/04_scoped_threads.md)

--- a/book/src/07_threads/05_channels.md
+++ b/book/src/07_threads/05_channels.md
@@ -1,41 +1,33 @@
-# Channels
+# 通道 (Channels)
 
-All our spawned threads have been fairly short-lived so far.\
-Get some input, run a computation, return the result, shut down.
+到目前为止我们 spawn 的线程都生命周期相当短：拿到输入、做计算、返回结果、关停。
 
-For our ticket management system, we want to do something different:
-a client-server architecture.
+对我们的工单管理系统，我们想做不一样的事：客户端-服务端 (client-server) 架构。
 
-We will have **one long-running server thread**, responsible for managing
-our state, the stored tickets.
+我们将有**一个长生命周期的服务端线程**，负责管理我们的状态——存储的工单。
 
-We will then have **multiple client threads**.\
-Each client will be able to send **commands** and **queries** to
-the stateful thread, in order to change its state (e.g. add a new ticket)
-or retrieve information (e.g. get the status of a ticket).\
-Client threads will run concurrently.
+我们再有**多个客户端线程**。\
+每个客户端能向有状态的线程发送**命令 (commands)** 和**查询 (queries)**，从而改变其状态（例如新增一张工单）或检索信息（例如获取一张工单的状态）。\
+客户端线程并发运行。
 
-## Communication
+## 通信 (Communication)
 
-So far we've only had very limited parent-child communication:
+到目前为止我们仅有非常有限的父子通信：
 
-- The spawned thread borrowed/consumed data from the parent context
-- The spawned thread returned data to the parent when joined
+- 被 spawn 的线程从父上下文借用/消费数据
+- 被 spawn 的线程在 join 时把数据返还给父线程
 
-This isn't enough for a client-server design.\
-Clients need to be able to send and receive data from the server thread
-_after_ it has been launched.
+这对客户端-服务端设计是不够的。\
+客户端需要能在服务端线程被启动 _之后_ 与之收发数据。
 
-We can solve the issue using **channels**.
+我们可以用**通道 (channels)** 解决这个问题。
 
-## Channels
+## 通道 (Channels)
 
-Rust's standard library provides **multi-producer, single-consumer** (mpsc) channels
-in its `std::sync::mpsc` module.\
-There are two channel flavours: bounded and unbounded. We'll stick to the unbounded
-version for now, but we'll discuss the pros and cons later on.
+Rust 标准库在 `std::sync::mpsc` 模块中提供了**多生产者单消费者 (multi-producer, single-consumer, mpsc)** 通道。\
+通道有两种风味：有界 (bounded) 和无界 (unbounded)。我们暂时用无界版本，稍后再讨论它们的优缺点。
 
-Channel creation looks like this:
+通道创建是这样：
 
 ```rust
 use std::sync::mpsc::channel;
@@ -43,31 +35,31 @@ use std::sync::mpsc::channel;
 let (sender, receiver) = channel();
 ```
 
-You get a sender and a receiver.\
-You call `send` on the sender to push data into the channel.\
-You call `recv` on the receiver to pull data from the channel.
+你得到一个发送者 (sender) 和一个接收者 (receiver)。\
+对发送者调用 `send` 把数据推入通道。\
+对接收者调用 `recv` 从通道拉取数据。
 
-### Multiple senders
+### 多个发送者 (Multiple senders)
 
-`Sender` is clonable: we can create multiple senders (e.g. one for
-each client thread) and they will all push data into the same channel.
+`Sender` 是可克隆的：我们可以创建多个发送者（例如每个客户端线程一个），它们都会把数据推入同一个通道。
 
-`Receiver`, instead, is not clonable: there can only be a single receiver
-for a given channel.
+`Receiver` 不可克隆：一个通道只能有一个接收者。
 
-That's what **mpsc** (multi-producer single-consumer) stands for!
+这就是 **mpsc**（multi-producer single-consumer）的含义！
 
-### Message type
+### 消息类型 (Message type)
 
-Both `Sender` and `Receiver` are generic over a type parameter `T`.\
-That's the type of the _messages_ that can travel on our channel.
+`Sender` 与 `Receiver` 都对类型参数 `T` 泛型。\
+那就是能在我们通道上传输的 _消息_ 的类型。
 
-It could be a `u64`, a struct, an enum, etc.
+可以是 `u64`、结构体、枚举等。
 
-### Errors
+### 错误 (Errors)
 
-Both `send` and `recv` can fail.\
-`send` returns an error if the receiver has been dropped.\
-`recv` returns an error if all senders have been dropped and the channel is empty.
+`send` 和 `recv` 都可能失败。\
+如果接收者被丢弃，`send` 返回错误。\
+如果所有发送者都被丢弃且通道为空，`recv` 返回错误。
 
-In other words, `send` and `recv` error when the channel is effectively closed.
+换句话说，通道实际上关闭时 `send` 与 `recv` 会出错。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/05_channels.md)

--- a/book/src/07_threads/06_interior_mutability.md
+++ b/book/src/07_threads/06_interior_mutability.md
@@ -1,6 +1,6 @@
-# Interior mutability
+# 内部可变性 (Interior mutability)
 
-Let's take a moment to reason about the signature of `Sender`'s `send`:
+我们来稍微推敲一下 `Sender` 的 `send` 签名：
 
 ```rust
 impl<T> Sender<T> {
@@ -10,105 +10,96 @@ impl<T> Sender<T> {
 }
 ```
 
-`send` takes `&self` as its argument.\
-But it's clearly causing a mutation: it's adding a new message to the channel.
-What's even more interesting is that `Sender` is cloneable: we can have multiple instances of `Sender`
-trying to modify the channel state **at the same time**, from different threads.
+`send` 接受 `&self` 作为参数。\
+但它显然在引发修改：往通道里加入了一条新消息。
+更有意思的是 `Sender` 是可克隆的：我们可以让多个 `Sender` 实例从不同线程**同时**尝试修改通道状态。
 
-That's the key property we are using to build this client-server architecture. But why does it work?
-Doesn't it violate Rust's rules about borrowing? How are we performing mutations via an _immutable_ reference?
+这是我们用来构建 client-server 架构的关键性质。但它为什么有效？
+难道这不违反 Rust 关于借用的规则吗？我们怎么能通过一个 _不可变_ 引用执行修改？
 
-## Shared rather than immutable references
+## 共享引用而非不可变引用 (Shared rather than immutable references)
 
-When we introduced the borrow-checker, we named the two types of references we can have in Rust:
+我们引入借用检查器时，把 Rust 中的两种引用命名为：
 
-- immutable references (`&T`)
-- mutable references (`&mut T`)
+- 不可变引用 (immutable references) `&T`
+- 可变引用 (mutable references) `&mut T`
 
-It would have been more accurate to name them:
+把它们叫作下列名字会更准确：
 
-- shared references (`&T`)
-- exclusive references (`&mut T`)
+- 共享引用 (shared references) `&T`
+- 独占引用 (exclusive references) `&mut T`
 
-Immutable/mutable is a mental model that works for the vast majority of cases, and it's a great one to get started
-with Rust. But it's not the whole story, as you've just seen: `&T` doesn't actually guarantee that the data it
-points to is immutable.\
-Don't worry, though: Rust is still keeping its promises.
-It's just that the terms are a bit more nuanced than they might seem at first.
+不可变/可变是一个对绝大多数情况都有效的心智模型，也是上手 Rust 时很好的一个。但它不是全貌，正如你刚刚看到的：`&T` 实际上并不保证它指向的数据不可变。\
+不过别担心：Rust 仍然在信守它的承诺。
+只是这些术语比表面看起来要更微妙。
 
 ## `UnsafeCell`
 
-Whenever a type allows you to mutate data through a shared reference, you're dealing with **interior mutability**.
+每当一个类型允许你通过共享引用修改数据时，你就在和**内部可变性 (interior mutability)** 打交道。
 
-By default, the Rust compiler assumes that shared references are immutable. It **optimises your code** based on that assumption.\
-The compiler can reorder operations, cache values, and do all sorts of magic to make your code faster.
+默认情况下，Rust 编译器假设共享引用是不可变的。它基于这个假设**优化你的代码**。\
+编译器可以重排操作、缓存值，做各种把戏让你的代码更快。
 
-You can tell the compiler "No, this shared reference is actually mutable" by wrapping the data in an `UnsafeCell`.\
-Every time you see a type that allows interior mutability, you can be certain that `UnsafeCell` is involved,
-either directly or indirectly.\
-Using `UnsafeCell`, raw pointers and `unsafe` code, you can mutate data through shared references.
+你可以通过把数据包到 `UnsafeCell` 里告诉编译器"不，这个共享引用其实是可变的"。\
+每次你看到一个允许内部可变性的类型，可以确定 `UnsafeCell` 牵涉其中——直接或间接地。\
+借助 `UnsafeCell`、原始指针和 `unsafe` 代码，你可以通过共享引用修改数据。
 
-Let's be clear, though: `UnsafeCell` isn't a magic wand that allows you to ignore the borrow-checker!\
-`unsafe` code is still subject to Rust's rules about borrowing and aliasing.
-It's an (advanced) tool that you can leverage to build **safe abstractions** whose safety can't be directly expressed
-in Rust's type system. Whenever you use the `unsafe` keyword you're telling the compiler:
-"I know what I'm doing, I won't violate your invariants, trust me."
+不过要说清楚：`UnsafeCell` 不是允许你忽略借用检查器的魔法棒！\
+`unsafe` 代码仍然受 Rust 关于借用与混叠 (aliasing) 规则的约束。
+它是一种（高级）工具，用来构建那些其安全性无法直接通过 Rust 类型系统表达的**安全抽象 (safe abstractions)**。每次你使用 `unsafe` 关键字，等于在告诉编译器："我知道我在做什么，不会违反你的不变量，相信我。"
 
-Every time you call an `unsafe` function, there will be documentation explaining its **safety preconditions**:
-under what circumstances it's safe to execute its `unsafe` block. You can find the ones for `UnsafeCell`
-[in `std`'s documentation](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html).
+每次你调用一个 `unsafe` 函数，文档都会说明它的**安全前置条件 (safety preconditions)**：
+执行其 `unsafe` 块要满足什么条件才安全。`UnsafeCell` 的可在 [`std` 文档](https://doc.rust-lang.org/std/cell/struct.UnsafeCell.html) 找到。
 
-We won't be using `UnsafeCell` directly in this course, nor will we be writing `unsafe` code.
-But it's important to know that it's there, why it exists and how it relates to the types you use
-every day in Rust.
+我们这门课不会直接使用 `UnsafeCell`，也不会写 `unsafe` 代码。
+但了解它存在、为什么存在以及它跟你日常使用的 Rust 类型有何关系，是重要的。
 
-## Key examples
+## 关键例子 (Key examples)
 
-Let's go through a couple of important `std` types that leverage interior mutability.\
-These are types that you'll encounter somewhat often in Rust code, especially if you peek under the hood of
-some the libraries you use.
+我们看几个利用内部可变性的重要 `std` 类型。\
+它们是你在 Rust 代码中相当常见的类型，特别是当你揭开你使用的库的盖子时。
 
-### Reference counting
+### 引用计数 (Reference counting)
 
-`Rc` is a reference-counted pointer.\
-It wraps around a value and keeps track of how many references to the value exist.
-When the last reference is dropped, the value is deallocated.\
-The value wrapped in an `Rc` is immutable: you can only get shared references to it.
+`Rc` 是一个引用计数指针。\
+它包裹一个值，并跟踪有多少个对该值的引用存在。
+当最后一个引用被丢弃时，该值被释放。\
+被 `Rc` 包裹的值是不可变的：你只能得到对它的共享引用。
 
 ```rust
 use std::rc::Rc;
 
 let a: Rc<String> = Rc::new("My string".to_string());
-// Only one reference to the string data exists.
+// 字符串数据只有一个引用。
 assert_eq!(Rc::strong_count(&a), 1);
 
-// When we call `clone`, the string data is not copied!
-// Instead, the reference count for `Rc` is incremented.
+// 调用 `clone` 不会复制字符串数据！
+// 只是把 `Rc` 的引用计数加 1。
 let b = Rc::clone(&a);
 assert_eq!(Rc::strong_count(&a), 2);
 assert_eq!(Rc::strong_count(&b), 2);
-// ^ Both `a` and `b` point to the same string data
-//   and share the same reference counter.
+// ^ `a` 和 `b` 都指向同一份字符串数据
+//   并共享同一个引用计数器。
 ```
 
-`Rc` uses `UnsafeCell` internally to allow shared references to increment and decrement the reference count.
+`Rc` 内部用 `UnsafeCell` 来允许共享引用增减引用计数。
 
 ### `RefCell`
 
-`RefCell` is one of the most common examples of interior mutability in Rust.
-It allows you to mutate the value wrapped in a `RefCell` even if you only have an
-immutable reference to the `RefCell` itself.
+`RefCell` 是 Rust 中内部可变性最常见的例子之一。
+它允许你在只持有 `RefCell` 的不可变引用时，仍能修改被 `RefCell` 包裹的值。
 
-This is done via **runtime borrow checking**.
-The `RefCell` keeps track of the number (and type) of references to the value it contains at runtime.
-If you try to borrow the value mutably while it's already borrowed immutably,
-the program will panic, ensuring that Rust's borrowing rules are always enforced.
+这是通过**运行时借用检查 (runtime borrow checking)** 实现的。
+`RefCell` 在运行时跟踪它所包含值的引用数量（与类型）。
+如果你尝试在已存在不可变借用时再做可变借用，程序会 panic，确保 Rust 的借用规则始终被强制执行。
 
 ```rust
 use std::cell::RefCell;
 
 let x = RefCell::new(42);
 
-let y = x.borrow(); // Immutable borrow
-let z = x.borrow_mut(); // Panics! There is an active immutable borrow.
+let y = x.borrow(); // 不可变借用
+let z = x.borrow_mut(); // panic！已有活跃的不可变借用。
 ```
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/06_interior_mutability.md)

--- a/book/src/07_threads/07_ack.md
+++ b/book/src/07_threads/07_ack.md
@@ -1,16 +1,16 @@
-# Two-way communication
+# 双向通信 (Two-way communication)
 
-In our current client-server implementation, communication flows in one direction: from the client to the server.\
-The client has no way of knowing if the server received the message, executed it successfully, or failed.
-That's not ideal.
+我们当前的 client-server 实现里，通信只朝一个方向流动：从客户端到服务端。\
+客户端无从得知服务端是否收到消息、是否成功执行、还是失败了。
+这并不理想。
 
-To solve this issue, we can introduce a two-way communication system.
+要解决这个问题，我们可以引入双向通信系统。
 
-## Response channel
+## 响应通道 (Response channel)
 
-We need a way for the server to send a response back to the client.\
-There are various ways to do this, but the simplest option is to include a `Sender` channel in
-the message that the client sends to the server. After processing the message, the server can use
-this channel to send a response back to the client.
+我们需要一种方式让服务端把响应送回客户端。\
+有多种方式可以做到，但最简单的选项是把一个 `Sender` 通道也包含在客户端发给服务端的消息里。处理完消息后，服务端可以用这个通道把响应送回客户端。
 
-This is a fairly common pattern in Rust applications built on top of message-passing primitives.
+这是建立在消息传递原语 (message-passing primitives) 之上的 Rust 应用中相当常见的模式。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/07_ack.md)

--- a/book/src/07_threads/08_client.md
+++ b/book/src/07_threads/08_client.md
@@ -1,8 +1,7 @@
-# A dedicated `Client` type
+# 专用的 `Client` 类型 (A dedicated `Client` type)
 
-All the interactions from the client side have been fairly low-level: you have to
-manually create a response channel, build the command, send it to the server, and
-then call `recv` on the response channel to get the response.
+到目前为止从客户端侧的所有交互都相当低层：你必须手动创建响应通道、构建命令、把它发给服务端，再对响应通道调用 `recv` 取响应。
 
-This is a lot of boilerplate code that could be abstracted away, and that's
-exactly what we're going to do in this exercise.
+这有大量样板代码可以抽象出去，本练习要做的正是这件事。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/08_client.md)

--- a/book/src/07_threads/09_bounded.md
+++ b/book/src/07_threads/09_bounded.md
@@ -1,19 +1,16 @@
-# Bounded vs unbounded channels
+# 有界 vs 无界通道 (Bounded vs unbounded channels)
 
-So far we've been using unbounded channels.\
-You can send as many messages as you want, and the channel will grow to accommodate them.\
-In a multi-producer single-consumer scenario, this can be problematic: if the producers
-enqueue messages at a faster rate than the consumer can process them, the channel will
-keep growing, potentially consuming all available memory.
+到目前为止我们都在使用无界通道。\
+你想发多少消息都行，通道会自己增长以容纳它们。\
+在多生产者单消费者场景里，这可能有问题：如果生产者入队消息的速率比消费者处理的速率更快，通道会持续增长，可能消耗光所有可用内存。
 
-Our recommendation is to **never** use an unbounded channel in a production system.\
-You should always enforce an upper limit on the number of messages that can be enqueued using a
-**bounded channel**.
+我们的建议是：在生产系统里**永远不要**使用无界通道。\
+你应当总是用**有界通道 (bounded channel)** 对可入队的消息数量设置上限。
 
-## Bounded channels
+## 有界通道 (Bounded channels)
 
-A bounded channel has a fixed capacity.\
-You can create one by calling `sync_channel` with a capacity greater than zero:
+有界通道有固定容量。\
+可以通过用大于零的容量调用 `sync_channel` 来创建一个：
 
 ```rust
 use std::sync::mpsc::sync_channel;
@@ -21,23 +18,24 @@ use std::sync::mpsc::sync_channel;
 let (sender, receiver) = sync_channel(10);
 ```
 
-`receiver` has the same type as before, `Receiver<T>`.\
-`sender`, instead, is an instance of `SyncSender<T>`.
+`receiver` 类型同前，依然是 `Receiver<T>`。\
+`sender` 这次是 `SyncSender<T>` 实例。
 
-### Sending messages
+### 发送消息 (Sending messages)
 
-You have two different methods to send messages through a `SyncSender`:
+通过 `SyncSender` 发送消息有两种不同的方法：
 
-- `send`: if there is space in the channel, it will enqueue the message and return `Ok(())`.\
-  If the channel is full, it will block and wait until there is space available.
-- `try_send`: if there is space in the channel, it will enqueue the message and return `Ok(())`.\
-  If the channel is full, it will return `Err(TrySendError::Full(value))`, where `value` is the message that couldn't be sent.
+- `send`：如果通道有空间，入队消息并返回 `Ok(())`。\
+  如果通道满了，会阻塞并等待直到有可用空间。
+- `try_send`：如果通道有空间，入队消息并返回 `Ok(())`。\
+  如果通道满了，会返回 `Err(TrySendError::Full(value))`，其中 `value` 是没能发送出去的消息。
 
-Depending on your use case, you might want to use one or the other.
+依据你的用例选择其一。
 
-### Backpressure
+### 背压 (Backpressure)
 
-The main advantage of using bounded channels is that they provide a form of **backpressure**.\
-They force the producers to slow down if the consumer can't keep up.
-The backpressure can then propagate through the system, potentially affecting the whole architecture and
-preventing end users from overwhelming the system with requests.
+使用有界通道的主要优点是它们提供了一种**背压 (backpressure)** 形式。\
+它们强制生产者在消费者跟不上时减速。
+背压随后可以在系统中传播，可能影响整个架构，防止终端用户用海量请求把系统压垮。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/09_bounded.md)

--- a/book/src/07_threads/10_patch.md
+++ b/book/src/07_threads/10_patch.md
@@ -1,27 +1,24 @@
-# Update operations
+# 更新操作 (Update operations)
 
-So far we've implemented only insertion and retrieval operations.\
-Let's see how we can expand the system to provide an update operation.
+到目前为止我们只实现了插入和检索操作。\
+看看怎么把系统扩展为提供更新操作。
 
-## Legacy updates
+## 旧版的更新 (Legacy updates)
 
-In the non-threaded version of the system, updates were fairly straightforward: `TicketStore` exposed a
-`get_mut` method that allowed the caller to obtain a mutable reference to a ticket, and then modify it.
+在系统的非线程版本里，更新相当直接：`TicketStore` 暴露了一个 `get_mut` 方法，允许调用方拿到工单的可变引用并修改它。
 
-## Multithreaded updates
+## 多线程下的更新 (Multithreaded updates)
 
-The same strategy won't work in the current multithreaded version. The borrow checker would
-stop us: `SyncSender<&mut Ticket>` isn't `'static` because `&mut Ticket` doesn't satisfy the `'static` lifetime, therefore
-they can't be captured by the closure that gets passed to `std::thread::spawn`.
+同样的策略在当前的多线程版本里行不通。借用检查器会拦下我们：`SyncSender<&mut Ticket>` 不是 `'static`，因为 `&mut Ticket` 不满足 `'static` 生命周期，因此它们不能被传给 `std::thread::spawn` 的闭包捕获。
 
-There are a few ways to work around this limitation. We'll explore a few of them in the following exercises.
+要绕开这个限制有几种方式。我们会在接下来的几个练习里探索其中几种。
 
-### Patching
+### 打补丁 (Patching)
 
-We can't send a `&mut Ticket` over a channel, therefore we can't mutate on the client-side.\
-Can we mutate on the server-side?
+我们没法把 `&mut Ticket` 通过通道发送，所以无法在客户端侧进行修改。\
+那能不能在服务端侧修改？
 
-We can, if we tell the server what needs to be changed. In other words, if we send a **patch** to the server:
+可以——只要我们告诉服务端要改什么。换言之，给服务端发送一个**补丁 (patch)**：
 
 ```rust
 struct TicketPatch {
@@ -32,8 +29,10 @@ struct TicketPatch {
 }
 ```
 
-The `id` field is mandatory, since it's required to identify the ticket that needs to be updated.\
-All other fields are optional:
+`id` 字段是必需的，因为它用来识别要更新哪张工单。\
+其他字段都是可选的：
 
-- If a field is `None`, it means that the field should not be changed.
-- If a field is `Some(value)`, it means that the field should be changed to `value`.
+- 如果某字段为 `None`，意味着该字段不应被改变。
+- 如果某字段为 `Some(value)`，意味着该字段应被改为 `value`。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/10_patch.md)

--- a/book/src/07_threads/11_locks.md
+++ b/book/src/07_threads/11_locks.md
@@ -1,92 +1,81 @@
-# Locks, `Send` and `Arc`
+# 锁、`Send` 与 `Arc` (Locks, `Send` and `Arc`)
 
-The patching strategy you just implemented has a major drawback: it's racy.\
-If two clients send patches for the same ticket roughly at same time, the server will apply them in an arbitrary order.
-Whoever enqueues their patch last will overwrite the changes made by the other client.
+你刚实现的打补丁策略有个主要缺点：它有竞争 (racy)。\
+如果两个客户端几乎同时为同一张工单发送补丁，服务端会以任意顺序应用它们。
+后入队补丁的那位会覆盖前者所做的更改。
 
-## Version numbers
+## 版本号 (Version numbers)
 
-We could try to fix this by using a **version number**.\
-Each ticket gets assigned a version number upon creation, set to `0`.\
-Whenever a client sends a patch, they must include the current version number of the ticket alongside the
-desired changes. The server will only apply the patch if the version number matches the one it has stored.
+我们可以尝试用**版本号 (version number)** 修复这个问题。\
+每张工单创建时被赋予一个版本号，初始为 `0`。\
+每当客户端发送补丁时，必须连同当前的版本号和期望的更改一起发出。服务端只在版本号与它存储的版本号匹配时才应用补丁。
 
-In the scenario described above, the server would reject the second patch, because the version number would
-have been incremented by the first patch and thus wouldn't match the one sent by the second client.
+在前面描述的场景中，服务端会拒绝第二个补丁，因为版本号已被第一个补丁递增，与第二个客户端发送的版本号不匹配。
 
-This approach is fairly common in distributed systems (e.g. when client and servers don't share memory),
-and it is known as **optimistic concurrency control**.\
-The idea is that most of the time, conflicts won't happen, so we can optimize for the common case.
-You know enough about Rust by now to implement this strategy on your own as a bonus exercise, if you want to.
+这种方式在分布式系统里相当常见（例如客户端和服务端不共享内存时），称为**乐观并发控制 (optimistic concurrency control)**。\
+其思想是：大多数时候不会发生冲突，因此可以为常见场景做优化。
+你目前对 Rust 已经了解得够多，可以作为附加练习自行实现这种策略。
 
-## Locking
+## 加锁 (Locking)
 
-We can also fix the race condition by introducing a **lock**.\
-Whenever a client wants to update a ticket, they must first acquire a lock on it. While the lock is active,
-no other client can modify the ticket.
+我们也可以通过引入**锁 (lock)** 来修复竞争。\
+每当客户端想更新工单时，必须先获取它上面的锁。锁活跃期间，其他客户端不能修改这张工单。
 
-Rust's standard library provides two different locking primitives: `Mutex<T>` and `RwLock<T>`.\
-Let's start with `Mutex<T>`. It stands for **mut**ual **ex**clusion, and it's the simplest kind of lock:
-it allows only one thread to access the data, no matter if it's for reading or writing.
+Rust 标准库提供了两种不同的锁原语：`Mutex<T>` 和 `RwLock<T>`。\
+先从 `Mutex<T>` 开始。它代表 **mut**ual **ex**clusion（互斥锁），是最简单的锁：
+不论读写，一次只允许一个线程访问数据。
 
-`Mutex<T>` wraps the data it protects, and it's therefore generic over the type of the data.\
-You can't access the data directly: the type system forces you to acquire a lock first using either `Mutex::lock` or
-`Mutex::try_lock`. The former blocks until the lock is acquired, the latter returns immediately with an error if the lock
-can't be acquired.\
-Both methods return a guard object that dereferences to the data, allowing you to modify it. The lock is released when
-the guard is dropped.
+`Mutex<T>` 包裹它所保护的数据，因此对数据类型是泛型的。\
+你不能直接访问数据：类型系统强制你必须先用 `Mutex::lock` 或 `Mutex::try_lock` 获取锁。前者会阻塞直到锁被获取，后者在无法获取锁时立即返回错误。\
+两种方法都返回一个 guard 对象，guard 解引用得到数据，从而允许你修改它。当 guard 被丢弃时锁被释放。
 
 ```rust
 use std::sync::Mutex;
 
-// An integer protected by a mutex lock
+// 一个被互斥锁保护的整数
 let lock = Mutex::new(0);
 
-// Acquire a lock on the mutex
+// 在 mutex 上获取一把锁
 let mut guard = lock.lock().unwrap();
 
-// Modify the data through the guard,
-// leveraging its `Deref` implementation
+// 通过 guard 借助其 `Deref` 实现修改数据
 *guard += 1;
 
-// The lock is released when `data` goes out of scope
-// This can be done explicitly by dropping the guard
-// or happen implicitly when the guard goes out of scope
+// 当 `data` 离开作用域时锁被释放
+// 也可以显式 drop guard 主动释放
+// 或当 guard 离开作用域时隐式释放
 drop(guard)
 ```
 
-## Locking granularity
+## 锁粒度 (Locking granularity)
 
-What should our `Mutex` wrap?\
-The simplest option would be to wrap the entire `TicketStore` in a single `Mutex`.\
-This would work, but it would severely limit the system's performance: you wouldn't be able to read tickets in parallel,
-because every read would have to wait for the lock to be released.\
-This is known as **coarse-grained locking**.
+我们的 `Mutex` 应该包裹什么？\
+最简单的选项是用单个 `Mutex` 包裹整个 `TicketStore`。\
+这能工作，但会严重限制系统性能：你无法并行读取工单，因为每次读取都得等锁释放。\
+这种做法叫**粗粒度锁 (coarse-grained locking)**。
 
-It would be better to use **fine-grained locking**, where each ticket is protected by its own lock.
-This way, clients can keep working with tickets in parallel, as long as they aren't trying to access the same ticket.
+更好的做法是**细粒度锁 (fine-grained locking)**：每张工单由自己的锁保护。
+这样客户端可以继续并行处理工单，只要他们没在尝试访问同一张工单。
 
 ```rust
-// The new structure, with a lock for each ticket
+// 新结构，每张工单一把锁
 struct TicketStore {
     tickets: BTreeMap<TicketId, Mutex<Ticket>>,
 }
 ```
 
-This approach is more efficient, but it has a downside: `TicketStore` has to become **aware** of the multithreaded
-nature of the system; up until now, `TicketStore` has been blissfully ignoring the existence of threads.\
-Let's go for it anyway.
+这种方式更高效，但有个缺点：`TicketStore` 必须**意识到 (aware of)** 系统的多线程性质；到目前为止 `TicketStore` 一直福里地忽略线程的存在。\
+不管怎样，我们要走这条路。
 
-## Who holds the lock?
+## 谁持有锁？(Who holds the lock?)
 
-For the whole scheme to work, the lock must be passed to the client that wants to modify the ticket.\
-The client can then directly modify the ticket (as if they had a `&mut Ticket`) and release the lock when they're done.
+要让整个方案运转起来，锁必须传给想修改工单的客户端。\
+客户端随后可以直接修改工单（仿佛拥有 `&mut Ticket`），完成后释放锁。
 
-This is a bit tricky.\
-We can't send a `Mutex<Ticket>` over a channel, because `Mutex` is not `Clone` and
-we can't move it out of the `TicketStore`. Could we send the `MutexGuard` instead?
+这有点棘手。\
+我们没法把 `Mutex<Ticket>` 通过通道发送，因为 `Mutex` 不是 `Clone`，并且我们不能从 `TicketStore` 中把它移走 (move out)。我们能不能把 `MutexGuard` 发过去？
 
-Let's test the idea with a small example:
+用一个小例子检验一下这个想法：
 
 ```rust
 use std::thread::spawn;
@@ -102,13 +91,12 @@ fn main() {
         receiver.recv().unwrap();
     });
 
-    // Try to send the guard over the channel
-    // to another thread
+    // 尝试把 guard 通过通道发到另一个线程
     sender.send(guard);
 }
 ```
 
-The compiler is not happy with this code:
+编译器对这段代码不满意：
 
 ```text
 error[E0277]: `MutexGuard<'_, i32>` cannot be sent between 
@@ -131,62 +119,55 @@ error[E0277]: `MutexGuard<'_, i32>` cannot be sent between
 note: required because it's used within this closure
 ```
 
-`MutexGuard<'_, i32>` is not `Send`: what does it mean?
+`MutexGuard<'_, i32>` 不是 `Send`：这是什么意思？
 
 ## `Send`
 
-`Send` is a marker trait that indicates that a type can be safely transferred from one thread to another.\
-`Send` is also an auto-trait, just like `Sized`; it's automatically implemented (or not implemented) for your type
-by the compiler, based on its definition.\
-You can also implement `Send` manually for your types, but it requires `unsafe` since you have to guarantee that the
-type is indeed safe to send between threads for reasons that the compiler can't automatically verify.
+`Send` 是一个标记特质 (marker trait)，表示类型可以安全地从一个线程转移到另一个线程。\
+`Send` 也是自动特质 (auto-trait)，跟 `Sized` 一样；编译器根据类型的定义自动为你的类型实现（或不实现）它。\
+你也可以为自己的类型手动实现 `Send`，但需要 `unsafe`，因为你必须保证这个类型确实可以安全地在线程间发送，编译器无法自动验证这点。
 
-### Channel requirements
+### 通道的要求 (Channel requirements)
 
-`Sender<T>`, `SyncSender<T>` and `Receiver<T>` are `Send` if and only if `T` is `Send`.\
-That's because they are used to send values between threads, and if the value itself is not `Send`, it would be
-unsafe to send it between threads.
+`Sender<T>`、`SyncSender<T>` 和 `Receiver<T>` 当且仅当 `T` 是 `Send` 时才是 `Send`。\
+因为它们用于在线程间发送值，如果值本身不是 `Send`，在线程间发送它就不安全。
 
 ### `MutexGuard`
 
-`MutexGuard` is not `Send` because the underlying operating system primitives that `Mutex` uses to implement
-the lock require (on some platforms) that the lock must be released by the same thread that acquired it.\
-If we were to send a `MutexGuard` to another thread, the lock would be released by a different thread, which would
-lead to undefined behavior.
+`MutexGuard` 不是 `Send`，因为 `Mutex` 实现锁所依赖的底层操作系统原语在某些平台上要求锁必须由获取它的同一个线程释放。\
+如果我们把 `MutexGuard` 发到另一个线程，锁就会被另一个线程释放，这会导致未定义行为。
 
-## Our challenges
+## 我们的挑战 (Our challenges)
 
-Summing it up:
+总结一下：
 
-- We can't send a `MutexGuard` over a channel. So we can't lock on the server-side and then modify the ticket on the
-  client-side.
-- We can send a `Mutex` over a channel because it's `Send` as long as the data it protects is `Send`, which is the
-  case for `Ticket`.
-  At the same time, we can't move the `Mutex` out of the `TicketStore` nor clone it.
+- 我们不能通过通道发送 `MutexGuard`，所以不能在服务端侧加锁、再在客户端侧修改工单。
+- 我们可以通过通道发送 `Mutex`，因为只要它保护的数据是 `Send`，它本身就是 `Send`，对 `Ticket` 来说成立。
+  与此同时，我们既不能把 `Mutex` 从 `TicketStore` 中移走，也不能克隆它。
 
-How can we solve this conundrum?\
-We need to look at the problem from a different angle.
-To lock a `Mutex`, we don't need an owned value. A shared reference is enough, since `Mutex` uses internal mutability:
+怎么解开这个难题？\
+我们需要换个角度看问题。
+要锁住一个 `Mutex`，我们不需要拥有所有权的值。一个共享引用就够了，因为 `Mutex` 使用内部可变性：
 
 ```rust
 impl<T> Mutex<T> {
-    // `&self`, not `self`!
+    // `&self`，不是 `self`！
     pub fn lock(&self) -> LockResult<MutexGuard<'_, T>> {
-        // Implementation details
+        // 实现细节
     }
 }
 ```
 
-It is therefore enough to send a shared reference to the client.\
-We can't do that directly, though, because the reference would have to be `'static` and that's not the case.\
-In a way, we need an "owned shared reference". It turns out that Rust has a type that fits the bill: `Arc`.
+因此把共享引用送到客户端就足够了。\
+不过我们没法直接这么做，因为引用得是 `'static` 而事实并非如此。\
+某种意义上，我们需要一种"具有所有权的共享引用 (owned shared reference)"。事实证明 Rust 有一个类型正好满足要求：`Arc`。
 
-## `Arc` to the rescue
+## `Arc` 来救场 (`Arc` to the rescue)
 
-`Arc` stands for **atomic reference counting**.\
-`Arc` wraps around a value and keeps track of how many references to the value exist.
-When the last reference is dropped, the value is deallocated.\
-The value wrapped in an `Arc` is immutable: you can only get shared references to it.
+`Arc` 代表**原子引用计数 (atomic reference counting)**。\
+`Arc` 包裹一个值，并跟踪有多少对它的引用存在。
+当最后一个引用被丢弃时，该值被释放。\
+被 `Arc` 包裹的值是不可变的：你只能拿到对它的共享引用。
 
 ```rust
 use std::sync::Arc;
@@ -194,33 +175,32 @@ use std::sync::Arc;
 let data: Arc<u32> = Arc::new(0);
 let data_clone = Arc::clone(&data);
 
-// `Arc<T>` implements `Deref<T>`, so can convert 
-// a `&Arc<T>` to a `&T` using deref coercion
+// `Arc<T>` 实现了 `Deref<T>`，所以能借助解引用强制转换
+// 把 `&Arc<T>` 转为 `&T`
 let data_ref: &u32 = &data;
 ```
 
-If you're having a déjà vu moment, you're right: `Arc` sounds very similar to `Rc`, the reference-counted pointer we
-introduced when talking about interior mutability. The difference is thread-safety: `Rc` is not `Send`, while `Arc` is.
-It boils down to the way the reference count is implemented: `Rc` uses a "normal" integer, while `Arc` uses an
-**atomic** integer, which can be safely shared and modified across threads.
+如果你有种似曾相识的感觉，没错：`Arc` 听起来与我们讲内部可变性时介绍的引用计数指针 `Rc` 非常相似。区别在于线程安全：`Rc` 不是 `Send`，而 `Arc` 是。
+归根结底是引用计数实现方式的差别：`Rc` 用"普通"整数，而 `Arc` 用**原子 (atomic)** 整数，可以安全地跨线程共享与修改。
 
 ## `Arc<Mutex<T>>`
 
-If we pair `Arc` with `Mutex`, we finally get a type that:
+把 `Arc` 与 `Mutex` 配在一起，我们终于得到一种类型，它：
 
-- Can be sent between threads, because:
-  - `Arc` is `Send` if `T` is `Send`, and
-  - `Mutex` is `Send` if `T` is `Send`.
-  - `T` is `Ticket`, which is `Send`.
-- Can be cloned, because `Arc` is `Clone` no matter what `T` is.
-  Cloning an `Arc` increments the reference count, the data is not copied.
-- Can be used to modify the data it wraps, because `Arc` lets you get a shared
-  reference to `Mutex<T>` which can in turn be used to acquire a lock.
+- 可以在线程间发送，因为：
+  - 当 `T` 是 `Send` 时 `Arc` 是 `Send`，
+  - 当 `T` 是 `Send` 时 `Mutex` 是 `Send`。
+  - `T` 是 `Ticket`，是 `Send` 的。
+- 可以克隆，因为不论 `T` 是什么，`Arc` 都是 `Clone`。
+  克隆 `Arc` 会增加引用计数，数据并未被复制。
+- 可以用来修改它包裹的数据，因为 `Arc` 让你拿到对 `Mutex<T>` 的共享引用，进而可以获取锁。
 
-We have all the pieces we need to implement the locking strategy for our ticket store.
+我们已具备实现工单存储锁策略所需的所有零件。
 
-## Further reading
+## 进一步阅读
 
-- We won't be covering the details of atomic operations in this course, but you can find more information
-  [in the `std` documentation](https://doc.rust-lang.org/std/sync/atomic/index.html) as well as in the
-  ["Rust atomics and locks" book](https://marabos.nl/atomics/).
+- 本课程不涵盖原子操作的细节，更多信息可在
+  [`std` 文档](https://doc.rust-lang.org/std/sync/atomic/index.html) 以及
+  ["Rust atomics and locks" 一书](https://marabos.nl/atomics/)中找到。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/11_locks.md)

--- a/book/src/07_threads/12_rw_lock.md
+++ b/book/src/07_threads/12_rw_lock.md
@@ -1,45 +1,42 @@
-# Readers and writers
+# 读者与写者 (Readers and writers)
 
-Our new `TicketStore` works, but its read performance is not great: there can only be one client at a time
-reading a specific ticket, because `Mutex<T>` doesn't distinguish between readers and writers.
+我们新的 `TicketStore` 能用，但读取性能不算好：同一时刻只有一个客户端能读取某张特定工单，因为 `Mutex<T>` 不区分读者和写者。
 
-We can solve the issue by using a different locking primitive: `RwLock<T>`.\
-`RwLock<T>` stands for **read-write lock**. It allows **multiple readers** to access the data simultaneously,
-but only one writer at a time.
+我们可以通过改用另一种锁原语 `RwLock<T>` 来解决这点。\
+`RwLock<T>` 代表**读写锁 (read-write lock)**。它允许**多个读者**同时访问数据，但同时只允许一个写者。
 
-`RwLock<T>` has two methods to acquire a lock: `read` and `write`.\
-`read` returns a guard that allows you to read the data, while `write` returns a guard that allows you to modify it.
+`RwLock<T>` 有两个获取锁的方法：`read` 和 `write`。\
+`read` 返回一个允许读数据的 guard；`write` 返回一个允许修改数据的 guard。
 
 ```rust
 use std::sync::RwLock;
 
-// An integer protected by a read-write lock
+// 一个被读写锁保护的整数
 let lock = RwLock::new(0);
 
-// Acquire a read lock on the RwLock
+// 在 RwLock 上获取一个读锁
 let guard1 = lock.read().unwrap();
 
-// Acquire a **second** read lock
-// while the first one is still active
+// 在第一个仍活跃时
+// 再获取**第二**个读锁
 let guard2 = lock.read().unwrap();
 ```
 
-## Trade-offs
+## 取舍 (Trade-offs)
 
-On the surface, `RwLock<T>` seems like a no-brainer: it provides a superset of the functionality of `Mutex<T>`.
-Why would you ever use `Mutex<T>` if you can use `RwLock<T>` instead?
+表面上看 `RwLock<T>` 像不假思索的选择：它提供了 `Mutex<T>` 功能的超集。
+为什么还要用 `Mutex<T>` 呢？
 
-There are two key reasons:
+有两个关键原因：
 
-- Locking a `RwLock<T>` is more expensive than locking a `Mutex<T>`.\
-  This is because `RwLock<T>` has to keep track of the number of active readers and writers, while `Mutex<T>`
-  only has to keep track of whether the lock is held or not.
-  This performance overhead is not an issue if there are more readers than writers, but if the workload
-  is write-heavy `Mutex<T>` might be a better choice.
-- `RwLock<T>` can cause **writer starvation**.\
-  If there are always readers waiting to acquire the lock, writers might never get a chance to run.\
-  `RwLock<T>` doesn't provide any guarantees about the order in which readers and writers are granted access to the lock.
-  It depends on the policy implemented by the underlying OS, which might not be fair to writers.
+- 锁住 `RwLock<T>` 比锁住 `Mutex<T>` 更昂贵。\
+  这是因为 `RwLock<T>` 必须跟踪活跃的读者和写者数量，而 `Mutex<T>` 只需跟踪锁是否被持有。
+  如果读多于写，这点性能开销不是问题；但如果是写密集 (write-heavy) 工作负载，`Mutex<T>` 可能是更好的选择。
+- `RwLock<T>` 可能导致**写者饿死 (writer starvation)**。\
+  如果总有读者在等锁，写者可能永远轮不到运行。\
+  `RwLock<T>` 不保证读者和写者获取锁的顺序。
+  这取决于底层 OS 实现的策略，可能对写者不公平。
 
-In our case, we can expect the workload to be read-heavy (since most clients will be reading tickets, not modifying them),
-so `RwLock<T>` is a good choice.
+我们的场景中，可以预期工作负载是读密集的（多数客户端在读工单而不是修改），所以 `RwLock<T>` 是个好选择。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/12_rw_lock.md)

--- a/book/src/07_threads/13_without_channels.md
+++ b/book/src/07_threads/13_without_channels.md
@@ -1,54 +1,46 @@
-# Design review
+# 设计回顾 (Design review)
 
-Let's take a moment to review the journey we've been through.
+我们花点时间回顾走过的路。
 
-## Lockless with channel serialization
+## 无锁 + 通道串行化 (Lockless with channel serialization)
 
-Our first implementation of a multithreaded ticket store used:
+我们多线程工单存储的第一版实现使用了：
 
-- a single long-lived thread (server), to hold the shared state
-- multiple clients sending requests to it via channels from their own threads.
+- 一个长生命周期线程（服务端），持有共享状态
+- 多个客户端，从各自线程通过通道向它发送请求
 
-No locking of the state was necessary, since the server was the only one modifying the state. That's because
-the "inbox" channel naturally **serialized** incoming requests: the server would process them one by one.\
-We've already discussed the limitations of this approach when it comes to patching behaviour, but we didn't
-discuss the performance implications of the original design: the server could only process one request at a time,
-including reads.
+不需要对状态加锁，因为只有服务端在修改状态。这是因为
+"收件箱"通道天然把进入的请求**串行化 (serialized)**：服务端逐一处理。\
+我们之前讨论过这种方式在打补丁行为上的局限，但没讨论原始设计的性能影响：服务端一次只能处理一个请求，包括读。
 
-## Fine-grained locking
+## 细粒度锁 (Fine-grained locking)
 
-We then moved to a more sophisticated design, where each ticket was protected by its own lock and
-clients could independently decide if they wanted to read or atomically modify a ticket, acquiring the appropriate lock.
+随后我们转向了更复杂的设计：每张工单由自己的锁保护，客户端可以独立决定要读取还是原子修改某张工单，并获取相应的锁。
 
-This design allows for better parallelism (i.e. multiple clients can read tickets at the same time), but it is
-still fundamentally **serial**: the server processes commands one by one. In particular, it hands out locks to clients
-one by one.
+这种设计允许更好的并行性（即多个客户端可同时读取工单），但根本上仍然是**串行 (serial)** 的：服务端逐一处理命令；尤其是它逐一发放锁给客户端。
 
-Could we remove the channels entirely and allow clients to directly access the `TicketStore`, relying exclusively on
-locks to synchronize access?
+我们能不能干脆去掉通道，让客户端直接访问 `TicketStore`，纯靠锁来同步访问？
 
-## Removing channels
+## 移除通道 (Removing channels)
 
-We have two problems to solve:
+我们要解决两个问题：
 
-- Sharing `TicketStore` across threads
-- Synchronizing access to the store
+- 跨线程共享 `TicketStore`
+- 同步对 store 的访问
 
-### Sharing `TicketStore` across threads
+### 跨线程共享 `TicketStore` (Sharing `TicketStore` across threads)
 
-We want all threads to refer to the same state, otherwise we don't really have a multithreaded system—we're just
-running multiple single-threaded systems in parallel.\
-We've already encountered this problem when we tried to share a lock across threads: we can use an `Arc`.
+我们希望所有线程引用同一份状态，否则就不算真正的多线程系统——只是并行运行多个单线程系统。\
+我们之前在跨线程共享锁时已经遇到过这个问题：可以用 `Arc`。
 
-### Synchronizing access to the store
+### 同步对 store 的访问 (Synchronizing access to the store)
 
-There is one interaction that's still lockless thanks to the serialization provided by the channels: inserting
-(or removing) a ticket from the store.\
-If we remove the channels, we need to introduce (another) lock to synchronize access to the `TicketStore` itself.
+有一种交互一直靠通道串行化提供的无锁性质：往 store 里插入（或移除）工单。\
+如果我们移除通道，需要引入（另一把）锁来同步对 `TicketStore` 本身的访问。
 
-If we use a `Mutex`, then it makes no sense to use an additional `RwLock` for each ticket: the `Mutex` will
-already serialize access to the entire store, so we wouldn't be able to read tickets in parallel anyway.\
-If we use a `RwLock`, instead, we can read tickets in parallel. We just need to pause all reads while inserting
-or removing a ticket.
+如果用 `Mutex`，那就没必要再为每张工单加 `RwLock`：`Mutex` 已经把对整个 store 的访问串行化，无论如何都无法并行读取工单。\
+如果改用 `RwLock`，则可以并行读取工单，只需在插入或移除工单时暂停所有读。
 
-Let's go down this path and see where it leads us.
+让我们沿这条路走下去看看会到哪儿。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/13_without_channels.md)

--- a/book/src/07_threads/14_sync.md
+++ b/book/src/07_threads/14_sync.md
@@ -1,28 +1,27 @@
 # `Sync`
 
-Before we wrap up this chapter, let's talk about another key trait in Rust's standard library: `Sync`.
+收尾本章前，我们再谈 Rust 标准库中另一个关键特质：`Sync`。
 
-`Sync` is an auto trait, just like `Send`.\
-It is automatically implemented by all types that can be safely **shared** between threads.
+`Sync` 是自动特质 (auto trait)，跟 `Send` 一样。\
+它会自动为所有可以安全地在线程间**共享 (shared)** 的类型实现。
 
-In other words: `T` is Sync if `&T` is `Send`.
+换句话说：当 `&T` 是 `Send` 时 `T` 就是 `Sync`。
 
-## `T: Sync` doesn't imply `T: Send`
+## `T: Sync` 不蕴含 `T: Send` (`T: Sync` doesn't imply `T: Send`)
 
-It's important to note that `T` can be `Sync` without being `Send`.\
-For example: `MutexGuard` is not `Send`, but it is `Sync`.
+要注意 `T` 可以是 `Sync` 而不是 `Send`。\
+例如：`MutexGuard` 不是 `Send`，但它是 `Sync`。
 
-It isn't `Send` because the lock must be released on the same thread that acquired it, therefore we don't
-want `MutexGuard` to be dropped on a different thread.\
-But it is `Sync`, because giving a `&MutexGuard` to another thread has no impact on where the lock is released.
+它不是 `Send`，是因为锁必须由获取它的同一个线程释放，因此我们不希望 `MutexGuard` 在另一个线程上被丢弃。\
+但它是 `Sync`，因为把 `&MutexGuard` 给另一个线程并不影响锁在哪儿被释放。
 
-## `T: Send` doesn't imply `T: Sync`
+## `T: Send` 不蕴含 `T: Sync` (`T: Send` doesn't imply `T: Sync`)
 
-The opposite is also true: `T` can be `Send` without being `Sync`.\
-For example: `RefCell<T>` is `Send` (if `T` is `Send`), but it is not `Sync`.
+反过来也成立：`T` 可以是 `Send` 而不是 `Sync`。\
+例如：`RefCell<T>`（当 `T` 是 `Send` 时）是 `Send`，但不是 `Sync`。
 
-`RefCell<T>` performs runtime borrow checking, but the counters it uses to track borrows are not thread-safe.
-Therefore, having multiple threads holding a `&RefCell` would lead to a data race, with potentially
-multiple threads obtaining mutable references to the same data. Hence `RefCell` is not `Sync`.\
-`Send` is fine, instead, because when we send a `RefCell` to another thread we're not
-leaving behind any references to the data it contains, hence no risk of concurrent mutable access.
+`RefCell<T>` 做运行时借用检查，但它用来跟踪借用的计数器不是线程安全的。
+因此，多个线程同时持有 `&RefCell` 会导致数据竞争 (data race)，可能多个线程同时拿到对同一数据的可变引用。所以 `RefCell` 不是 `Sync`。\
+`Send` 则没问题，因为把 `RefCell` 发到另一个线程时不会留下任何指向它内部数据的引用，因此不存在并发可变访问的风险。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/07_threads/14_sync.md)


### PR DESCRIPTION
进度：75/100 → 90/100（+15）

第 7 章全章翻译：线程基础 / `'static` / `Box::leak` / 作用域线程 / 通道 / 内部可变性 + Rc/RefCell / 双向通信 / Client 抽象 / 有界通道+背压 / 补丁 / Mutex+Send+Arc / RwLock 取舍 / 无通道设计 / Sync。

同步更新 README checklist 与 welcome.md 进度数。

https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA)_