### PR TITLE
翻译: 第 8 章 异步 + 后记（10 篇，全书翻译完成 🎉）

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,18 +162,18 @@
 - [x] ✅ 07_threads/14_sync.md
 
 ### 第8章：Futures (异步编程)
-- [ ] ⏸️ 08_futures/00_intro.md
-- [ ] ⏸️ 08_futures/01_async_fn.md
-- [ ] ⏸️ 08_futures/02_spawn.md
-- [ ] ⏸️ 08_futures/03_runtime.md
-- [ ] ⏸️ 08_futures/04_future.md
-- [ ] ⏸️ 08_futures/05_blocking.md
-- [ ] ⏸️ 08_futures/06_async_aware_primitives.md
-- [ ] ⏸️ 08_futures/07_cancellation.md
-- [ ] ⏸️ 08_futures/08_outro.md
+- [x] ✅ 08_futures/00_intro.md
+- [x] ✅ 08_futures/01_async_fn.md
+- [x] ✅ 08_futures/02_spawn.md
+- [x] ✅ 08_futures/03_runtime.md
+- [x] ✅ 08_futures/04_future.md
+- [x] ✅ 08_futures/05_blocking.md
+- [x] ✅ 08_futures/06_async_aware_primitives.md
+- [x] ✅ 08_futures/07_cancellation.md
+- [x] ✅ 08_futures/08_outro.md
 
 ### 进阶内容 (Going Further)
-- [ ] ⏸️ going_further.md
+- [x] ✅ going_further.md
 
 ## 许可证
 

--- a/book/src/01_intro/00_welcome.md
+++ b/book/src/01_intro/00_welcome.md
@@ -1,7 +1,7 @@
 # 欢迎
 
 > 🌏 **中文版说明**
-> 本书正在翻译中，当前进度约 90%。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看最新中文版。
+> 本书已翻译完成（100%）。访问 [100.rust-roof.top](https://100.rust-roof.top) 查看中文版。
 > 英文原版请访问 [rust-exercises.com](https://rust-exercises.com)。
 > 翻译问题请提交到 [GitHub Issues](https://github.com/tangivis/100-exercises-to-learn-rust/issues)。
 

--- a/book/src/08_futures/00_intro.md
+++ b/book/src/08_futures/00_intro.md
@@ -1,11 +1,13 @@
-# Async Rust
+# 异步 Rust (Async Rust)
 
-Threads are not the only way to write concurrent programs in Rust.\
-In this chapter we'll explore another approach: **asynchronous programming**.
+线程并不是 Rust 中编写并发程序的唯一方式。\
+本章我们要探索另一种方式：**异步编程 (asynchronous programming)**。
 
-In particular, you'll get an introduction to:
+具体来说，你将获得对以下内容的入门：
 
-- The `async`/`.await` keywords, to write asynchronous code effortlessly
-- The `Future` trait, to represent computations that may not be complete yet
-- `tokio`, the most popular runtime for running asynchronous code
-- The cooperative nature of Rust asynchronous model, and how this affects your code
+- `async`/`.await` 关键字，让你毫不费力地写异步代码
+- `Future` 特质，表示可能尚未完成的计算
+- `tokio`，最流行的运行异步代码的运行时
+- Rust 异步模型的协作 (cooperative) 性质，以及它如何影响你的代码
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/00_intro.md)

--- a/book/src/08_futures/01_async_fn.md
+++ b/book/src/08_futures/01_async_fn.md
@@ -1,58 +1,49 @@
-# Asynchronous functions
+# 异步函数 (Asynchronous functions)
 
-All the functions and methods you've written so far were eager.\
-Nothing happened until you invoked them. But once you did, they ran to
-completion: they did **all** their work, and then returned their output.
+到目前为止你写的所有函数和方法都是急切 (eager) 的。\
+你不调用它们就什么也不会发生。但一旦调用，它们会运行直到完成：把**所有**工作做完，然后返回输出。
 
-Sometimes that's undesirable.\
-For example, if you're writing an HTTP server, there might be a lot of
-**waiting**: waiting for the request body to arrive, waiting for the
-database to respond, waiting for a downstream service to reply, etc.
+有时这并不理想。\
+例如，如果你写一个 HTTP 服务器，可能会有大量的**等待 (waiting)**：等待请求体到达、等待数据库响应、等待下游服务回复，等等。
 
-What if you could do something else while you're waiting?\
-What if you could choose to give up midway through a computation?\
-What if you could choose to prioritise another task over the current one?
+要是你能在等待的同时做别的事呢？\
+要是你能在某个计算进行到一半时选择放弃呢？\
+要是你能选择把另一个任务的优先级置于当前任务之上呢？
 
-That's where **asynchronous functions** come in.
+这就轮到**异步函数 (asynchronous functions)** 上场了。
 
 ## `async fn`
 
-You use the `async` keyword to define an asynchronous function:
+你用 `async` 关键字定义异步函数：
 
 ```rust
 use tokio::net::TcpListener;
 
-// This function is asynchronous
+// 这个函数是异步的
 async fn bind_random() -> TcpListener {
     // [...]
 }
 ```
 
-What happens if you call `bind_random` as you would a regular function?
+如果你像调用普通函数一样调用 `bind_random` 会怎样？
 
 ```rust
 fn run() {
-    // Invoke `bind_random`
+    // 调用 `bind_random`
     let listener = bind_random();
-    // Now what?
+    // 接下来呢？
 }
 ```
 
-Nothing happens!\
-Rust doesn't start executing `bind_random` when you call it,
-not even as a background task (as you might expect based on your experience
-with other languages).
-Asynchronous functions in Rust are **lazy**: they don't do any work until you
-explicitly ask them to.
-Using Rust's terminology, we say that `bind_random` returns a **future**, a type
-that represents a computation that may complete later. They're called futures
-because they implement the `Future` trait, an interface that we'll examine in
-detail later on in this chapter.
+什么也不会发生！\
+Rust 在你调用 `bind_random` 时不会开始执行它，
+也不会作为后台任务启动它（你可能基于其他语言的经验会这么期待）。
+Rust 中的异步函数是**惰性 (lazy)** 的：你不显式要求它们做事，它们就什么也不做。
+用 Rust 的术语说，`bind_random` 返回一个**未来体 (future)**，一种表示可能稍后完成的计算的类型。它们叫 future 是因为它们实现了 `Future` 特质——本章稍后会详细讲解的接口。
 
 ## `.await`
 
-The most common way to ask an asynchronous function to do some work is to use
-the `.await` keyword:
+要让异步函数执行任务，最常见的方式是使用 `.await` 关键字：
 
 ```rust
 use tokio::net::TcpListener;
@@ -62,67 +53,58 @@ async fn bind_random() -> TcpListener {
 }
 
 async fn run() {
-    // Invoke `bind_random` and wait for it to complete
+    // 调用 `bind_random` 并等待它完成
     let listener = bind_random().await;
-    // Now `listener` is ready
+    // 现在 `listener` 就绪
 }
 ```
 
-`.await` doesn't return control to the caller until the asynchronous function
-has run to completion—e.g. until the `TcpListener` has been created in the example above.
+`.await` 直到异步函数运行完成（例如上面例子里 `TcpListener` 创建完成）才把控制权交还给调用方。
 
-## Runtimes
+## 运行时 (Runtimes)
 
-If you're puzzled, you're right to be!\
-We've just said that the perk of asynchronous functions
-is that they don't do **all** their work at once. We then introduced `.await`, which
-doesn't return until the asynchronous function has run to completion. Haven't we
-just re-introduced the problem we were trying to solve? What's the point?
+如果你感到困惑，那是合理的！\
+我们刚说异步函数的好处是它们不会一次把**所有**工作做完。然后我们又引入了 `.await`，它直到异步函数运行完成才返回。难道不是把我们想解决的问题又引回来了吗？这有什么意义？
 
-Not quite! A lot happens behind the scenes when you call `.await`!\
-You're yielding control to an **async runtime**, also known as an **async executor**.
-Executors are where the magic happens: they are in charge of managing all your
-ongoing asynchronous **tasks**. In particular, they balance two different goals:
+并非如此！调用 `.await` 时幕后发生了很多事！\
+你正把控制权让给一个**异步运行时 (async runtime)**，也叫**异步执行器 (async executor)**。
+执行器是魔法发生的地方：它负责管理你所有正在进行的异步**任务 (tasks)**。具体来说，它在两个目标之间取得平衡：
 
-- **Progress**: they make sure that tasks make progress whenever they can.
-- **Efficiency**: if a task is waiting for something, they try to make sure that
-  another task can run in the meantime, fully utilising the available resources.
+- **推进 (Progress)**：确保任务在能推进时尽量推进。
+- **效率 (Efficiency)**：如果一个任务在等待某事，确保另一个任务能在此期间运行，充分利用可用资源。
 
-### No default runtime
+### 没有默认运行时 (No default runtime)
 
-Rust is fairly unique in its approach to asynchronous programing: there is
-no default runtime. The standard library doesn't ship with one. You need to
-bring your own!
+Rust 在异步编程的方式上相当独特：没有默认运行时。
+标准库不附带运行时。你需要自己带一个！
 
-In most cases, you'll choose one of the options available in the ecosystem.
-Some runtimes are designed to be broadly applicable, a solid option for most applications.
-`tokio` and `async-std` belong to this category. Other runtimes are optimised for
-specific use cases—e.g. `embassy` for embedded systems.
+大多数情况下，你会从生态中现有的选项中选一个。
+有些运行时被设计为通用，是大多数应用的稳妥选择。
+`tokio` 和 `async-std` 属于这一类。还有些运行时为特定场景做了优化——例如嵌入式系统的 `embassy`。
 
-Throughout this course we'll rely on `tokio`, the most popular runtime for general-purpose
-asynchronous programming in Rust.
+整门课程我们都依赖 `tokio`，它是 Rust 中通用异步编程最流行的运行时。
 
 ### `#[tokio::main]`
 
-The entrypoint of your executable, the `main` function, must be a synchronous function.
-That's where you're supposed to set up and launch your chosen async runtime.
+你可执行文件的入口点 `main` 函数必须是同步函数。
+你应当在它里面设置并启动你选的异步运行时。
 
-Most runtimes provide a macro to make this easier. For `tokio`, it's `tokio::main`:
+大多数运行时提供宏来简化这个工作。`tokio` 的是 `tokio::main`：
 
 ```rust
 #[tokio::main]
 async fn main() {
-    // Your async code goes here
+    // 这里写你的异步代码
 }
 ```
 
-which expands to:
+它会展开为：
 
 ```rust
 fn main() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(
-        // Your async function goes here
+        // 这里写你的异步函数
         // [...]
     );
 }
@@ -130,15 +112,15 @@ fn main() {
 
 ### `#[tokio::test]`
 
-The same goes for tests: they must be synchronous functions.\
-Each test function is run in its own thread, and you're responsible for
-setting up and launching an async runtime if you need to run async code
-in your tests.\
-`tokio` provides a `#[tokio::test]` macro to make this easier:
+测试也一样：必须是同步函数。\
+每个测试函数在其自己的线程中运行，如果你需要在测试中执行异步代码，需要自己设置并启动异步运行时。\
+`tokio` 提供了 `#[tokio::test]` 宏来简化这件事：
 
 ```rust
 #[tokio::test]
 async fn my_test() {
-    // Your async test code goes here
+    // 这里写你的异步测试代码
 }
 ```
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/01_async_fn.md)

--- a/book/src/08_futures/02_spawn.md
+++ b/book/src/08_futures/02_spawn.md
@@ -1,6 +1,6 @@
-# Spawning tasks
+# spawn 任务 (Spawning tasks)
 
-Your solution to the previous exercise should look something like this:
+你对前一个练习的解决方案大概是这样：
 
 ```rust
 pub async fn echo(listener: TcpListener) -> Result<(), anyhow::Error> {
@@ -12,24 +12,20 @@ pub async fn echo(listener: TcpListener) -> Result<(), anyhow::Error> {
 }
 ```
 
-This is not bad!\
-If a long time passes between two incoming connections, the `echo` function will be idle
-(since `TcpListener::accept` is an asynchronous function), thus allowing the executor
-to run other tasks in the meantime.
+这不算差！\
+如果两次进入的连接之间间隔很长，`echo` 函数会处于空闲状态（因为 `TcpListener::accept` 是异步函数），从而允许执行器在此期间运行其他任务。
 
-But how can we actually have multiple tasks running concurrently?\
-If we always run our asynchronous functions until completion (by using `.await`), we'll never
-have more than one task running at a time.
+但我们怎么真正让多个任务并发运行？\
+如果总是 `.await` 让异步函数运行到完成，那同一时刻就永远只有一个任务运行。
 
-This is where the `tokio::spawn` function comes in.
+这就是 `tokio::spawn` 函数登场的地方。
 
 ## `tokio::spawn`
 
-`tokio::spawn` allows you to hand off a task to the executor, **without waiting for it to complete**.\
-Whenever you invoke `tokio::spawn`, you're telling `tokio` to continue running
-the spawned task, in the background, **concurrently** with the task that spawned it.
+`tokio::spawn` 让你把一个任务交给执行器，**而不等待它完成**。\
+每次调用 `tokio::spawn`，你都在告诉 `tokio` 在后台**并发**运行被 spawn 的任务，与 spawn 它的任务并行。
 
-Here's how you can use it to process multiple connections concurrently:
+下面看怎么用它来并发处理多个连接：
 
 ```rust
 use tokio::net::TcpListener;
@@ -37,9 +33,8 @@ use tokio::net::TcpListener;
 pub async fn echo(listener: TcpListener) -> Result<(), anyhow::Error> {
     loop {
         let (mut socket, _) = listener.accept().await?;
-        // Spawn a background task to handle the connection
-        // thus allowing the main task to immediately start 
-        // accepting new connections
+        // spawn 一个后台任务来处理连接，
+        // 让主任务可以立即继续接收新连接
         tokio::spawn(async move {
             let (mut reader, mut writer) = socket.split();
             tokio::io::copy(&mut reader, &mut writer).await?;
@@ -48,27 +43,23 @@ pub async fn echo(listener: TcpListener) -> Result<(), anyhow::Error> {
 }
 ```
 
-### Asynchronous blocks
+### 异步块 (Asynchronous blocks)
 
-In this example, we've passed an **asynchronous block** to `tokio::spawn`: `async move { /* */ }`
-Asynchronous blocks are a quick way to mark a region of code as asynchronous without having
-to define a separate async function.
+这个例子里我们把一个**异步块 (asynchronous block)** `async move { /* */ }` 传给了 `tokio::spawn`。
+异步块是把一段代码标记为异步的快捷方式，无需另定义一个异步函数。
 
 ### `JoinHandle`
 
-`tokio::spawn` returns a `JoinHandle`.\
-You can use `JoinHandle` to `.await` the background task, in the same way
-we used `join` for spawned threads.
+`tokio::spawn` 返回一个 `JoinHandle`。\
+你可以用 `JoinHandle` 来 `.await` 后台任务，跟 spawn 线程时使用 `join` 一样。
 
 ```rust
 pub async fn run() {
-    // Spawn a background task to ship telemetry data
-    // to a remote server
+    // spawn 一个后台任务把遥测数据发到远端服务器
     let handle = tokio::spawn(emit_telemetry());
-    // In the meantime, do some other useful work
+    // 与此同时做一些别的有用的事
     do_work().await;
-    // But don't return to the caller until 
-    // the telemetry data has been successfully delivered
+    // 但在遥测数据成功送达之前不返回给调用方
     handle.await;
 }
 
@@ -81,14 +72,12 @@ pub async fn do_work() {
 }
 ```
 
-### Panic boundary
+### Panic 边界 (Panic boundary)
 
-If a task spawned with `tokio::spawn` panics, the panic will be caught by the executor.\
-If you don't `.await` the corresponding `JoinHandle`, the panic won't be propagated to the spawner.
-Even if you do `.await` the `JoinHandle`, the panic won't be propagated automatically.
-Awaiting a `JoinHandle` returns a `Result`, with [`JoinError`](https://docs.rs/tokio/latest/tokio/task/struct.JoinError.html)
-as its error type. You can then check if the task panicked by calling `JoinError::is_panic` and
-choose what to do with the panic—either log it, ignore it, or propagate it.
+如果用 `tokio::spawn` spawn 的任务发生 panic，panic 会被执行器捕获。\
+如果你不 `.await` 对应的 `JoinHandle`，panic 不会传播给 spawn 它的方。
+即使你 `.await` 了 `JoinHandle`，panic 也不会自动传播。
+`.await` 一个 `JoinHandle` 会得到 `Result`，错误类型是 [`JoinError`](https://docs.rs/tokio/latest/tokio/task/struct.JoinError.html)。然后你可以调用 `JoinError::is_panic` 检查任务是否 panic 了，并选择如何处理这次 panic——记日志、忽略、或传播。
 
 ```rust
 use tokio::task::JoinError;
@@ -97,9 +86,9 @@ pub async fn run() {
     let handle = tokio::spawn(work());
     if let Err(e) = handle.await {
         if let Ok(reason) = e.try_into_panic() {
-            // The task has panicked
-            // We resume unwinding the panic,
-            // thus propagating it to the current task
+            // 任务 panic 了
+            // 我们恢复 panic 的展开，
+            // 从而把它传播到当前任务
             panic::resume_unwind(reason);
         }
     }
@@ -110,13 +99,15 @@ pub async fn work() {
 }
 ```
 
-### `std::thread::spawn` vs `tokio::spawn`
+### `std::thread::spawn` 与 `tokio::spawn` 对比
 
-You can think of `tokio::spawn` as the asynchronous sibling of `std::thread::spawn`.
+可以把 `tokio::spawn` 看作 `std::thread::spawn` 的异步孪生兄弟。
 
-Notice a key difference: with `std::thread::spawn`, you're delegating control to the OS scheduler.
-You're not in control of how threads are scheduled.
+注意一个关键区别：使用 `std::thread::spawn` 时，你把控制权交给了 OS 调度器。
+你无法控制线程如何被调度。
 
-With `tokio::spawn`, you're delegating to an async executor that runs entirely in
-user space. The underlying OS scheduler is not involved in the decision of which task
-to run next. We're in charge of that decision now, via the executor we chose to use.
+使用 `tokio::spawn` 时，你把控制权交给了一个完全运行在用户态的异步执行器。
+底层 OS 调度器并不参与决定接下来运行哪个任务。
+现在我们通过所选用的执行器来掌握这个决定。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/02_spawn.md)

--- a/book/src/08_futures/03_runtime.md
+++ b/book/src/08_futures/03_runtime.md
@@ -1,48 +1,37 @@
-# Runtime architecture
+# 运行时架构 (Runtime architecture)
 
-So far we've been talking about async runtimes as an abstract concept.
-Let's dig a bit deeper into the way they are implemented—as you'll see soon enough,
-it has an impact on our code.
+到目前为止我们一直把异步运行时当作一个抽象概念在谈。
+我们稍微深入它们的实现方式——你很快会看到，这对我们的代码有影响。
 
-## Flavors
+## 风味 (Flavors)
 
-`tokio` ships two different runtime _flavors_.
+`tokio` 提供两种不同的运行时 _风味 (flavors)_。
 
-You can configure your runtime via `tokio::runtime::Builder`:
+可以通过 `tokio::runtime::Builder` 配置运行时：
 
-- `Builder::new_multi_thread` gives you a **multithreaded `tokio` runtime**
-- `Builder::new_current_thread` will instead rely on the **current thread** for execution.
+- `Builder::new_multi_thread` 给你一个**多线程 `tokio` 运行时**
+- `Builder::new_current_thread` 则依赖**当前线程 (current thread)** 来执行。
 
-`#[tokio::main]` returns a multithreaded runtime by default, while
-`#[tokio::test]` uses a current thread runtime out of the box.
+`#[tokio::main]` 默认返回多线程运行时，
+而 `#[tokio::test]` 默认使用当前线程运行时。
 
-### Current thread runtime
+### 当前线程运行时 (Current thread runtime)
 
-The current-thread runtime, as the name implies, relies exclusively on the OS thread
-it was launched on to schedule and execute tasks.\
-When using the current-thread runtime, you have **concurrency** but no **parallelism**:
-asynchronous tasks will be interleaved, but there will always be at most one task running
-at any given time.
+当前线程运行时，顾名思义，仅依赖它启动所在的那个 OS 线程来调度和执行任务。\
+使用当前线程运行时时，你有**并发 (concurrency)** 但没有**并行 (parallelism)**：
+异步任务会被交错执行，但任意时刻最多只有一个任务在跑。
 
-### Multithreaded runtime
+### 多线程运行时 (Multithreaded runtime)
 
-When using the multithreaded runtime, instead, there can be up to `N` tasks running
-_in parallel_ at any given time, where `N` is the number of threads used by the
-runtime. By default, `N` matches the number of available CPU cores.
+而使用多线程运行时时，任意时刻最多可以有 `N` 个任务 _并行 (in parallel)_ 运行，其中 `N` 是运行时使用的线程数。默认情况下，`N` 等于可用 CPU 核心数。
 
-There's more: `tokio` performs **work-stealing**.\
-If a thread is idle, it won't wait around: it'll try to find a new task that's ready for
-execution, either from a global queue or by stealing it from the local queue of another
-thread.\
-Work-stealing can have significant performance benefits, especially on tail latencies,
-whenever your application is dealing with workloads that are not perfectly balanced
-across threads.
+还不止于此：`tokio` 实施**工作窃取 (work-stealing)**。\
+如果某线程空闲，它不会等着：会尝试找一个新的就绪任务来执行——要么从全局队列拿，要么从另一线程的本地队列偷。\
+当应用面对的工作负载在线程间不完全均衡时，工作窃取能带来显著的性能收益，尤其是对尾部延迟。
 
-## Implications
+## 影响 (Implications)
 
-`tokio::spawn` is flavor-agnostic: it'll work no matter if you're running on the multithreaded
-or current-thread runtime. The downside is that the signature assumes the worst case
-(i.e. multithreaded) and is constrained accordingly:
+`tokio::spawn` 是风味无关的：不管你跑在多线程还是当前线程运行时上都能工作。代价是它的签名按最坏情况（即多线程）做约束：
 
 ```rust
 pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
@@ -52,19 +41,17 @@ where
 { /* */ }
 ```
 
-Let's ignore the `Future` trait for now to focus on the rest.\
-`spawn` is asking all its inputs to be `Send` and have a `'static` lifetime.
+我们暂时忽略 `Future` 特质，关注其余部分。\
+`spawn` 要求所有输入都是 `Send` 且具有 `'static` 生命周期。
 
-The `'static` constraint follows the same rationale of the `'static` constraint
-on `std::thread::spawn`: the spawned task may outlive the context it was spawned
-from, therefore it shouldn't depend on any local data that may be de-allocated
-after the spawning context is destroyed.
+`'static` 约束遵循与 `std::thread::spawn` 上 `'static` 约束相同的逻辑：
+被 spawn 的任务可能比 spawn 它的上下文更长寿，因此不应依赖任何在 spawn 上下文销毁后可能被回收的本地数据。
 
 ```rust
 fn spawner() {
     let v = vec![1, 2, 3];
-    // This won't work, since `&v` doesn't
-    // live long enough.
+    // 这不会工作，因为 `&v`
+    // 活得不够长。
     tokio::spawn(async { 
         for x in &v {
             println!("{x}")
@@ -73,16 +60,17 @@ fn spawner() {
 }
 ```
 
-`Send`, on the other hand, is a direct consequence of `tokio`'s work-stealing strategy:
-a task that was spawned on thread `A` may end up being moved to thread `B` if that's idle,
-thus requiring a `Send` bound since we're crossing thread boundaries.
+`Send` 则是 `tokio` 工作窃取策略的直接后果：
+在线程 `A` 上 spawn 的任务可能被搬到空闲的线程 `B`，因此需要 `Send` 约束，因为我们要跨线程边界。
 
 ```rust
 fn spawner(input: Rc<u64>) {
-    // This won't work either, because
-    // `Rc` isn't `Send`.
+    // 这也不会工作，因为
+    // `Rc` 不是 `Send`。
     tokio::spawn(async move {
         println!("{}", input);
     })
 }
 ```
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/03_runtime.md)

--- a/book/src/08_futures/04_future.md
+++ b/book/src/08_futures/04_future.md
@@ -1,8 +1,8 @@
-# The `Future` trait
+# `Future` 特质 (The `Future` trait)
 
-## The local `Rc` problem
+## 局部 `Rc` 问题 (The local `Rc` problem)
 
-Let's go back to `tokio::spawn`'s signature:
+回到 `tokio::spawn` 的签名：
 
 ```rust
 pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
@@ -12,12 +12,11 @@ pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
 { /* */ }
 ```
 
-What does it _actually_ mean for `F` to be `Send`?\
-It implies, as we saw in the previous section, that whatever value it captures from the
-spawning environment has to be `Send`. But it goes further than that.
+`F` 是 `Send` 究竟意味着什么？\
+正如上一节所见，它意味着 `F` 从 spawn 环境捕获的所有值都得是 `Send`。但还不止如此。
 
-Any value that's _held across a .await point_ has to be `Send`.\
-Let's look at an example:
+任何 _跨越 .await 点_ 持有的值都必须是 `Send`。\
+看一个例子：
 
 ```rust
 use std::rc::Rc;
@@ -28,20 +27,19 @@ fn spawner() {
 }
 
 async fn example() {
-    // A value that's not `Send`,
-    // created _inside_ the async function
+    // 一个非 `Send` 的值，
+    // 在 async 函数 _内部_ 创建
     let non_send = Rc::new(1);
     
-    // A `.await` point that does nothing
+    // 一个什么也不做的 `.await` 点
     yield_now().await;
 
-    // The local non-`Send` value is still needed
-    // after the `.await`
+    // `.await` 之后仍需要这个本地非 `Send` 值
     println!("{}", non_send);
 }
 ```
 
-The compiler will reject this code:
+编译器会拒绝这段代码：
 
 ```text
 error: future cannot be sent between threads safely
@@ -67,25 +65,23 @@ note: required by a bound in `tokio::spawn`
     |                     ^^^^ required by this bound in `spawn`
 ```
 
-To understand why that's the case, we need to refine our understanding of
-Rust's asynchronous model.
+要理解这是为什么，我们得细化对 Rust 异步模型的理解。
 
-## The `Future` trait
+## `Future` 特质 (The `Future` trait)
 
-We stated early on that `async` functions return **futures**, types that implement
-the `Future` trait. You can think of a future as a **state machine**.
-It's in one of two states:
+我们早先说过 `async` 函数返回**未来体 (futures)**——实现了 `Future` 特质的类型。可以把 future 看作一个**状态机 (state machine)**。
+它处于两种状态之一：
 
-- **pending**: the computation has not finished yet.
-- **ready**: the computation has finished, here's the output.
+- **pending（待定）**：计算尚未完成。
+- **ready（就绪）**：计算已完成，输出在此。
 
-This is encoded in the trait definition:
+这点编码在特质定义里：
 
 ```rust
 trait Future {
     type Output;
     
-    // Ignore `Pin` and `Context` for now
+    // 暂时忽略 `Pin` 和 `Context`
     fn poll(
       self: Pin<&mut Self>, 
       cx: &mut Context<'_>
@@ -95,36 +91,32 @@ trait Future {
 
 ### `poll`
 
-The `poll` method is the heart of the `Future` trait.\
-A future on its own doesn't do anything. It needs to be **polled** to make progress.\
-When you call `poll`, you're asking the future to do some work.
-`poll` tries to make progress, and then returns one of the following:
+`poll` 方法是 `Future` 特质的核心。\
+future 自身什么也不做。它需要被**轮询 (polled)** 才能推进。\
+当你调用 `poll` 时，你在请求 future 做一些工作。
+`poll` 尝试推进，然后返回下列之一：
 
-- `Poll::Pending`: the future is not ready yet. You need to call `poll` again later.
-- `Poll::Ready(value)`: the future has finished. `value` is the result of the computation,
-  of type `Self::Output`.
+- `Poll::Pending`：future 尚未就绪。你需要稍后再调用 `poll`。
+- `Poll::Ready(value)`：future 已完成。`value` 是计算结果，类型为 `Self::Output`。
 
-Once `Future::poll` returns `Poll::Ready`, it should not be polled again: the future has
-completed, there's nothing left to do.
+一旦 `Future::poll` 返回 `Poll::Ready`，就不应再被 poll：future 已经完成，没有事可做了。
 
-### The role of the runtime
+### 运行时的角色 (The role of the runtime)
 
-You'll rarely, if ever, be calling poll directly.\
-That's the job of your async runtime: it has all the required information (the `Context`
-in `poll`'s signature) to ensure that your futures are making progress whenever they can.
+你很少（甚至从不）需要直接调用 `poll`。\
+那是异步运行时的工作：它拥有所需的所有信息（`poll` 签名中的 `Context`），确保你的 future 在能推进时尽量推进。
 
-## `async fn` and futures
+## `async fn` 与 future (`async fn` and futures)
 
-We've worked with the high-level interface, asynchronous functions.\
-We've now looked at the low-level primitive, the `Future trait`.
+我们已经使用过高层接口——异步函数。\
+现在又看了底层原语 `Future` 特质。
 
-How are they related?
+它们怎么关联？
 
-Every time you mark a function as asynchronous, that function will return a future.
-The compiler will transform the body of your asynchronous function into a **state machine**:
-one state for each `.await` point.
+每次你把函数标记为异步，那个函数就会返回一个 future。
+编译器会把异步函数体转换为一个**状态机 (state machine)**：每个 `.await` 点对应一个状态。
 
-Going back to our `Rc` example:
+回到我们的 `Rc` 例子：
 
 ```rust
 use std::rc::Rc;
@@ -137,7 +129,7 @@ async fn example() {
 }
 ```
 
-The compiler would transform it into an enum that looks somewhat like this:
+编译器会把它转换成一个看起来类似下面的枚举：
 
 ```rust
 pub enum ExampleFuture {
@@ -147,24 +139,17 @@ pub enum ExampleFuture {
 }
 ```
 
-When `example` is called, it returns `ExampleFuture::NotStarted`. The future has never
-been polled yet, so nothing has happened.\
-When the runtime polls it the first time, `ExampleFuture` will advance until the next
-`.await` point: it'll stop at the `ExampleFuture::YieldNow(Rc<i32>)` stage of the state
-machine, returning `Poll::Pending`.\
-When it's polled again, it'll execute the remaining code (`println!`) and
-return `Poll::Ready(())`.
+调用 `example` 时，它返回 `ExampleFuture::NotStarted`。future 还没被 poll 过，所以什么也没发生。\
+当运行时第一次 poll 它时，`ExampleFuture` 会推进到下一个 `.await` 点：会停在状态机的 `ExampleFuture::YieldNow(Rc<i32>)` 阶段，返回 `Poll::Pending`。\
+再次被 poll 时，它会执行剩余代码（`println!`）并返回 `Poll::Ready(())`。
 
-When you look at its state machine representation, `ExampleFuture`,
-it is now clear why `example` is not `Send`: it holds an `Rc`, therefore
-it cannot be `Send`.
+看到它的状态机表示 `ExampleFuture` 后，就清楚为什么 `example` 不是 `Send` 了：它持有一个 `Rc`，因此不能 `Send`。
 
-## Yield points
+## 让出点 (Yield points)
 
-As you've just seen with `example`, every `.await` point creates a new intermediate
-state in the lifecycle of a future.\
-That's why `.await` points are also known as **yield points**: your future _yields control_
-back to the runtime that was polling it, allowing the runtime to pause it and (if necessary)
-schedule another task for execution, thus making progress on multiple fronts concurrently.
+如刚才用 `example` 看到的，每个 `.await` 点都在 future 生命周期里创建一个新的中间状态。\
+这就是 `.await` 点也叫**让出点 (yield points)** 的原因：你的 future 把控制权 _让出 (yield)_ 给正在 poll 它的运行时，允许运行时暂停它，并（必要时）调度另一个任务执行，从而在多个方向上并发推进。
 
-We'll come back to the importance of yielding in a later section.
+我们会在后面一节再回到让出 (yield) 的重要性。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/04_future.md)

--- a/book/src/08_futures/05_blocking.md
+++ b/book/src/08_futures/05_blocking.md
@@ -1,59 +1,43 @@
-# Don't block the runtime
+# 不要阻塞运行时 (Don't block the runtime)
 
-Let's circle back to yield points.\
-Unlike threads, **Rust tasks cannot be preempted**.
+让我们回到让出点 (yield points)。\
+与线程不同，**Rust 任务不可被抢占 (preempted)**。
 
-`tokio` cannot, on its own, decide to pause a task and run another one in its place.
-The control goes back to the executor **exclusively** when the task yields—i.e.
-when `Future::poll` returns `Poll::Pending` or, in the case of `async fn`, when
-you `.await` a future.
+`tokio` 不能自行决定暂停一个任务并替它运行另一个。
+控制权**仅在**任务让出时回到执行器——也就是 `Future::poll` 返回 `Poll::Pending` 时，或者对 `async fn` 来说，你 `.await` 一个 future 时。
 
-This exposes the runtime to a risk: if a task never yields, the runtime will never
-be able to run another task. This is called **blocking the runtime**.
+这给运行时带来一个风险：如果一个任务从不让出，运行时就永远没法运行另一个任务。这叫**阻塞运行时 (blocking the runtime)**。
 
-## What is blocking?
+## 什么算阻塞？(What is blocking?)
 
-How long is too long? How much time can a task spend without yielding before it
-becomes a problem?
+多长才算太长？任务不让出能撑多久才会成问题？
 
-It depends on the runtime, the application, the number of in-flight tasks, and
-many other factors. But, as a general rule of thumb, try to spend less than 100
-microseconds between yield points.
+这取决于运行时、应用、在飞 (in-flight) 任务数以及许多其他因素。但作为一般经验法则，让出点之间的执行尽量不超过 100 微秒。
 
-## Consequences
+## 后果 (Consequences)
 
-Blocking the runtime can lead to:
+阻塞运行时可能导致：
 
-- **Deadlocks**: if the task that's not yielding is waiting for another task to
-  complete, and that task is waiting for the first one to yield, you have a deadlock.
-  No progress can be made, unless the runtime is able to schedule the other task on
-  a different thread.
-- **Starvation**: other tasks might not be able to run, or might run after a long
-  delay, which can lead to poor performances (e.g. high tail latencies).
+- **死锁 (Deadlocks)**：如果不让出的任务在等待另一个任务完成，而那个任务又在等第一个任务让出，那就是死锁。
+  无法推进——除非运行时能把另一个任务调度到不同线程上。
+- **饿死 (Starvation)**：其他任务可能跑不起来，或大幅延迟才跑起来，导致性能差（例如尾部延迟高）。
 
-## Blocking is not always obvious
+## 阻塞并不总是显而易见 (Blocking is not always obvious)
 
-Some types of operations should generally be avoided in async code, like:
+某些操作通常应当避免在异步代码里执行，例如：
 
-- Synchronous I/O. You can't predict how long it will take, and it's likely to be
-  longer than 100 microseconds.
-- Expensive CPU-bound computations.
+- 同步 I/O。你预测不了它要花多久，而且很可能超过 100 微秒。
+- 昂贵的 CPU 密集型计算。
 
-The latter category is not always obvious though. For example, sorting a vector with
-a few elements is not a problem; that evaluation changes if the vector has billions
-of entries.
+后一类不总是显而易见。例如，对几个元素的向量排序不是问题；如果向量有数十亿条目，评价就变了。
 
-## How to avoid blocking
+## 怎么避免阻塞 (How to avoid blocking)
 
-OK, so how do you avoid blocking the runtime assuming you _must_ perform an operation
-that qualifies or risks qualifying as blocking?\
-You need to move the work to a different thread. You don't want to use the so-called
-runtime threads, the ones used by `tokio` to run tasks.
+好，那么如果你 _必须_ 执行一项符合或可能符合阻塞条件的操作，怎么避免阻塞运行时？\
+你需要把工作搬到不同的线程上。你不希望使用所谓的运行时线程——也就是 `tokio` 用来跑任务的那些线程。
 
-`tokio` provides a dedicated threadpool for this purpose, called the **blocking pool**.
-You can spawn a synchronous operation on the blocking pool using the
-`tokio::task::spawn_blocking` function. `spawn_blocking` returns a future that resolves
-to the result of the operation when it completes.
+`tokio` 为此提供了一个专门的线程池，叫**阻塞池 (blocking pool)**。
+你可以用 `tokio::task::spawn_blocking` 把同步操作 spawn 到阻塞池上。`spawn_blocking` 返回一个 future，操作完成时该 future 解析为操作结果。
 
 ```rust
 use tokio::task;
@@ -64,16 +48,16 @@ fn expensive_computation() -> u64 {
 
 async fn run() {
     let handle = task::spawn_blocking(expensive_computation);
-    // Do other stuff in the meantime
+    // 在此期间做别的事
     let result = handle.await.unwrap();
 }
 ```
 
-The blocking pool is long-lived. `spawn_blocking` should be faster
-than creating a new thread directly via `std::thread::spawn`
-because the cost of thread initialization is amortized over multiple calls.
+阻塞池是长生命周期的。`spawn_blocking` 应当比直接通过 `std::thread::spawn` 创建新线程更快，
+因为线程初始化的成本被多次调用摊销了。
 
-## Further reading
+## 进一步阅读
 
-- Check out [Alice Ryhl's blog post](https://ryhl.io/blog/async-what-is-blocking/)
-  on the topic.
+- 看看 [Alice Ryhl 关于这个话题的博文](https://ryhl.io/blog/async-what-is-blocking/)。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/05_blocking.md)

--- a/book/src/08_futures/06_async_aware_primitives.md
+++ b/book/src/08_futures/06_async_aware_primitives.md
@@ -1,18 +1,14 @@
-# Async-aware primitives
+# 异步感知原语 (Async-aware primitives)
 
-If you browse `tokio`'s documentation, you'll notice that it provides a lot of types
-that "mirror" the ones in the standard library, but with an asynchronous twist:
-locks, channels, timers, and more.
+如果你浏览 `tokio` 的文档，会注意到它提供了大量"对应"标准库的类型——但带有异步特性：锁、通道、定时器等。
 
-When working in an asynchronous context, you should prefer these asynchronous alternatives
-to their synchronous counterparts.
+在异步上下文中工作时，应该优先使用这些异步替代品，而不是其同步对应物。
 
-To understand why, let's take a look at `Mutex`, the mutually exclusive lock we explored
-in the previous chapter.
+为了理解为什么，我们看 `Mutex`，前一章探索过的互斥锁。
 
-## Case study: `Mutex`
+## 案例分析：`Mutex` (Case study: `Mutex`)
 
-Let's look at a simple example:
+看一个简单例子：
 
 ```rust
 use std::sync::{Arc, Mutex};
@@ -21,44 +17,40 @@ async fn run(m: Arc<Mutex<Vec<u64>>>) {
     let guard = m.lock().unwrap();
     http_call(&guard).await;
     println!("Sent {:?} to the server", &guard);
-    // `guard` is dropped here
+    // `guard` 在这里被 drop
 }
 
-/// Use `v` as the body of an HTTP call.
+/// 把 `v` 用作 HTTP 调用的请求体。
 async fn http_call(v: &[u64]) {
   // [...]
 }
 ```
 
-### `std::sync::MutexGuard` and yield points
+### `std::sync::MutexGuard` 与让出点 (`std::sync::MutexGuard` and yield points)
 
-This code will compile, but it's dangerous.
+这段代码能编译，但很危险。
 
-We try to acquire a lock over a `Mutex` from `std` in an asynchronous context.
-We then hold on to the resulting `MutexGuard` across a yield point (the `.await` on
-`http_call`).
+我们尝试在异步上下文中获取一个来自 `std` 的 `Mutex` 的锁。
+然后我们跨越一个让出点持有得到的 `MutexGuard`（对 `http_call` 的 `.await`）。
 
-Let's imagine that there are two tasks executing `run`, concurrently, on a single-threaded
-runtime. We observe the following sequence of scheduling events:
+设想有两个任务在单线程运行时上并发地执行 `run`。我们观察到下面的调度事件序列：
 
 ```text
      Task A          Task B
         | 
-  Acquire lock
-Yields to runtime
+  获取锁
+让出给运行时
         | 
         +--------------+
                        |
-             Tries to acquire lock
+             尝试获取锁
 ```
 
-We have a deadlock. Task B will never manage to acquire the lock, because the lock
-is currently held by task A, which has yielded to the runtime before releasing the
-lock and won't be scheduled again because the runtime cannot preempt task B.
+我们死锁了。Task B 永远拿不到锁，因为锁当前由 Task A 持有，而 Task A 在释放锁之前已经让出给运行时，并且因为运行时不能抢占 Task B 而无法被再次调度。
 
 ### `tokio::sync::Mutex`
 
-You can solve the issue by switching to `tokio::sync::Mutex`:
+可以通过切换到 `tokio::sync::Mutex` 来解决：
 
 ```rust
 use std::sync::Arc;
@@ -68,62 +60,56 @@ async fn run(m: Arc<Mutex<Vec<u64>>>) {
     let guard = m.lock().await;
     http_call(&guard).await;
     println!("Sent {:?} to the server", &guard);
-    // `guard` is dropped here
+    // `guard` 在这里被 drop
 }
 ```
 
-Acquiring the lock is now an asynchronous operation, which yields back to the runtime
-if it can't make progress.\
-Going back to the previous scenario, the following would happen:
+获取锁现在是异步操作，无法推进时会让出给运行时。\
+回到前面的场景，会变成这样：
 
 ```text
        Task A          Task B
           | 
-  Acquires the lock
-  Starts `http_call`
-  Yields to runtime
+     获取锁
+   开始 `http_call`
+   让出给运行时
           | 
           +--------------+
                          |
-             Tries to acquire the lock
-              Cannot acquire the lock
-                 Yields to runtime
+                 尝试获取锁
+                  无法获取
+                  让出给运行时
                          |
           +--------------+
           |
-`http_call` completes      
-  Releases the lock
-   Yield to runtime
+   `http_call` 完成
+       释放锁
+    让出给运行时
           |
           +--------------+
                          |
-                 Acquires the lock
-                       [...]
+                     获取锁
+                      [...]
 ```
 
-All good!
+一切正常！
 
-### Multithreaded won't save you
+### 多线程救不了你 (Multithreaded won't save you)
 
-We've used a single-threaded runtime as the execution context in our
-previous example, but the same risk persists even when using a multithreaded
-runtime.\
-The only difference is in the number of concurrent tasks required to create the deadlock:
-in a single-threaded runtime, 2 are enough; in a multithreaded runtime, we
-would need `N+1` tasks, where `N` is the number of runtime threads.
+我们前面的例子用单线程运行时作为执行上下文，但即使使用多线程运行时，同样的风险依然存在。\
+唯一区别是制造死锁所需的并发任务数量：
+单线程运行时里 2 个就够；多线程运行时里需要 `N+1` 个，其中 `N` 是运行时线程数。
 
-### Downsides
+### 缺点 (Downsides)
 
-Having an async-aware `Mutex` comes with a performance penalty.\
-If you're confident that the lock isn't under significant contention
-_and_ you're careful to never hold it across a yield point, you can
-still use `std::sync::Mutex` in an asynchronous context.
+异步感知的 `Mutex` 带有性能代价。\
+如果你确信锁没有显著竞争，_并且_ 你小心从不跨越让出点持有它，仍然可以在异步上下文中使用 `std::sync::Mutex`。
 
-But weigh the performance benefit against the liveness risk you
-will incur.
+但要权衡这点性能收益与你将承担的活性 (liveness) 风险。
 
-## Other primitives
+## 其他原语 (Other primitives)
 
-We used `Mutex` as an example, but the same applies to `RwLock`, semaphores, etc.\
-Prefer async-aware versions when working in an asynchronous context to minimise
-the risk of issues.
+我们用 `Mutex` 作例子，但同样适用于 `RwLock`、信号量等。\
+在异步上下文中工作时，优先使用异步感知版本以最小化问题风险。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/06_async_aware_primitives.md)

--- a/book/src/08_futures/07_cancellation.md
+++ b/book/src/08_futures/07_cancellation.md
@@ -1,11 +1,11 @@
-# Cancellation
+# 取消 (Cancellation)
 
-What happens when a pending future is dropped?\
-The runtime will no longer poll it, therefore it won't make any further progress.
-In other words, its execution has been **cancelled**.
+一个待定 (pending) 的 future 被丢弃时会发生什么？\
+运行时不会再 poll 它，因此它不会再有任何进展。
+换句话说，它的执行已被**取消 (cancelled)**。
 
-In the wild, this often happens when working with timeouts.
-For example:
+实际中，这经常发生在使用超时时。
+例如：
 
 ```rust
 use tokio::time::timeout;
@@ -17,7 +17,7 @@ async fn http_call() {
 }
 
 async fn run() {
-    // Wrap the future with a `Timeout` set to expire in 10 milliseconds.
+    // 把 future 用一个 10 毫秒后到期的 `Timeout` 包起来。
     let duration = Duration::from_millis(10);
     if let Err(_) = timeout(duration, http_call()).await {
         println!("Didn't receive a value within 10 ms");
@@ -25,8 +25,8 @@ async fn run() {
 }
 ```
 
-When the timeout expires, the future returned by `http_call` will be cancelled.
-Let's imagine that this is `http_call`'s body:
+超时到期时，`http_call` 返回的 future 会被取消。
+设想 `http_call` 的函数体是这样：
 
 ```rust
 use std::net::TcpStream;
@@ -38,23 +38,16 @@ async fn http_call() {
 }
 ```
 
-Each yield point becomes a **cancellation point**.\
-`http_call` can't be preempted by the runtime, so it can only be discarded after
-it has yielded control back to the executor via `.await`.
-This applies recursively—e.g. `stream.write_all(&request)` is likely to have multiple
-yield points in its implementation. It is perfectly possible to see `http_call` pushing
-a _partial_ request before being cancelled, thus dropping the connection and never
-finishing transmitting the body.
+每个让出点都成为一个**取消点 (cancellation point)**。\
+`http_call` 不能被运行时抢占，所以只能在它通过 `.await` 让出控制权之后才被丢弃。
+这是递归的——例如 `stream.write_all(&request)` 的实现里很可能也有多个让出点。完全可能看到 `http_call` 推送了 _部分_ 请求之后被取消，从而丢弃连接、永远没把请求体发送完。
 
-## Clean up
+## 清理 (Clean up)
 
-Rust's cancellation mechanism is quite powerful—it allows the caller to cancel an ongoing task
-without needing any form of cooperation from the task itself.\
-At the same time, this can be quite dangerous. It may be desirable to perform a
-**graceful cancellation**, to ensure that some clean-up tasks are performed
-before aborting the operation.
+Rust 的取消机制相当强大——它允许调用方取消正在进行的任务，而无需任务本身做任何配合。\
+同时这也可能相当危险。可能希望执行**优雅取消 (graceful cancellation)**，确保在中止操作之前完成一些清理任务。
 
-For example, consider this fictional API for a SQL transaction:
+例如，看下面这个虚构的 SQL 事务 API：
 
 ```rust
 async fn transfer_money(
@@ -70,40 +63,38 @@ async fn transfer_money(
 }
 ```
 
-On cancellation, it'd be ideal to explicitly abort the pending transaction rather
-than leaving it hanging.
-Rust, unfortunately, doesn't provide a bullet-proof mechanism for this kind of
-**asynchronous** clean up operations.
+被取消时，理想情况是显式中止还在 pending 的事务，而不是把它挂在那。
+不幸的是，Rust 没有为这种**异步**清理操作提供万无一失的机制。
 
-The most common strategy is to rely on the `Drop` trait to schedule the required
-clean-up work. This can be by:
+最常见的策略是依赖 `Drop` 特质来调度所需的清理工作。可以是：
 
-- Spawning a new task on the runtime
-- Enqueueing a message on a channel
-- Spawning a background thread
+- 在运行时上 spawn 一个新任务
+- 把消息入队到一个通道
+- spawn 一个后台线程
 
-The optimal choice is contextual.
+最优选择取决于上下文。
 
-## Cancelling spawned tasks
+## 取消已 spawn 的任务 (Cancelling spawned tasks)
 
-When you spawn a task using `tokio::spawn`, you can no longer drop it;
-it belongs to the runtime.\
-Nonetheless, you can use its `JoinHandle` to cancel it if needed:
+当你用 `tokio::spawn` spawn 一个任务后，你不能再 drop 它；它属于运行时。\
+不过，如果需要，你可以用它的 `JoinHandle` 来取消它：
 
 ```rust
 async fn run() {
     let handle = tokio::spawn(/* some async task */);
-    // Cancel the spawned task
+    // 取消已 spawn 的任务
     handle.abort();
 }
 ```
 
-## Further reading
+## 进一步阅读
 
-- Be extremely careful when using `tokio`'s `select!` macro to "race" two different futures.
-  Retrying the same task in a loop is dangerous unless you can ensure **cancellation safety**.
-  Check out [`select!`'s documentation](https://tokio.rs/tokio/tutorial/select) for more details.\
-  If you need to interleave two asynchronous streams of data (e.g. a socket and a channel), prefer using
-  [`StreamExt::merge`](https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.merge) instead.
-- A [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html) may be
-  preferable to `JoinHandle::abort` in some cases.
+- 用 `tokio` 的 `select!` 宏"竞速"两个不同的 future 时要格外小心。
+  在循环中重试同一个任务很危险，除非你能确保**取消安全 (cancellation safety)**。
+  详情见 [`select!` 的文档](https://tokio.rs/tokio/tutorial/select)。\
+  如果你需要交错处理两个异步数据流（例如套接字和通道），优先使用
+  [`StreamExt::merge`](https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.merge)。
+- 在某些场合，[`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html)
+  可能比 `JoinHandle::abort` 更可取。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/07_cancellation.md)

--- a/book/src/08_futures/08_outro.md
+++ b/book/src/08_futures/08_outro.md
@@ -1,34 +1,24 @@
-# Outro
+# 收尾 (Outro)
 
-Rust's asynchronous model is quite powerful, but it does introduce additional
-complexity. Take time to know your tools: dive deep into `tokio`'s documentation
-and get familiar with its primitives to make the most out of it.
+Rust 的异步模型相当强大，但确实带来了额外的复杂度。花时间了解你的工具：深入 `tokio` 的文档，熟悉它的原语，让自己物尽其用。
 
-Keep in mind, as well, that there is ongoing work at the language and `std` level
-to streamline and "complete" Rust's asynchronous story. You may experience some
-rough edges in your day-to-day work due to some of these missing pieces.
+也请记住，语言层面与 `std` 层面都还在持续工作，以打磨并"补全"Rust 的异步故事。
+你日常工作中可能会因为某些缺失部分遇到一些粗糙之处。
 
-A few recommendations for a mostly-pain-free async experience:
+下面是几条让异步体验大体顺畅的建议：
 
-- **Pick a runtime and stick to it.**\
-  Some primitives (e.g. timers, I/O) are not portable across runtimes. Trying to
-  mix runtimes is likely to cause you pain. Trying to write code that's runtime
-  agnostic can significantly increase the complexity of your codebase. Avoid it
-  if you can.
-- **There is no stable `Stream`/`AsyncIterator` interface yet.**\
-  An `AsyncIterator` is, conceptually, an iterator that yields new items
-  asynchronously. There is ongoing design work, but no consensus (yet).
-  If you're using `tokio`, refer to [`tokio_stream`](https://docs.rs/tokio-stream/latest/tokio_stream/)
-  as your go-to interface.
-- **Be careful with buffering.**\
-  It is often the cause of subtle bugs. Check out
-  ["Barbara battles buffered streams"](https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/barbara_battles_buffered_streams.html)
-  for more details.
-- **There is no equivalent of scoped threads for asynchronous tasks**.\
-  Check out ["The scoped task trilemma"](https://without.boats/blog/the-scoped-task-trilemma/)
-  for more details.
+- **选定一个运行时并坚持使用它。**\
+  某些原语（例如定时器、I/O）在运行时之间不可移植。试图混用运行时很可能给你带来麻烦。试图写出运行时无关的代码可能显著增加代码库复杂度。能避免就避免。
+- **目前还没有稳定的 `Stream`/`AsyncIterator` 接口。**\
+  `AsyncIterator` 在概念上是异步产生新元素的迭代器。设计工作正在进行，但（暂时）还没有共识。
+  如果你用 `tokio`，把 [`tokio_stream`](https://docs.rs/tokio-stream/latest/tokio_stream/) 当作首选接口。
+- **小心缓冲。**\
+  它经常是隐蔽 bug 的根源。详情见
+  ["Barbara battles buffered streams"](https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/barbara_battles_buffered_streams.html)。
+- **异步任务还没有作用域线程的等价物。**\
+  详情见 ["The scoped task trilemma"](https://without.boats/blog/the-scoped-task-trilemma/)。
 
-Don't let these caveats scare you: asynchronous Rust is being used effectively
-at _massive_ scale (e.g. AWS, Meta) to power foundational services.\
-You will have to master it if you're planning building networked applications
-in Rust.
+不要被这些注意事项吓到：异步 Rust 正被有效地用在 _巨型_ 规模上（例如 AWS、Meta），驱动核心服务。\
+如果你打算用 Rust 构建网络应用，你将必须掌握它。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/08_futures/08_outro.md)

--- a/book/src/going_further.md
+++ b/book/src/going_further.md
@@ -1,52 +1,42 @@
-# Epilogue
+# 后记 (Epilogue)
 
-Our tour of Rust ends here.\
-It has been quite extensive, but by no means exhaustive: Rust is a language with
-a large surface area, and an even larger ecosystem!\
-Don't let this scare you, though: there's **no need to learn everything**.
-You'll pick up whatever is necessary to be effective in the domain
-(backend, embedded, CLIs, GUIs, etc.) **while working on your projects**.
+我们的 Rust 之旅在此告一段落。\
+内容相当广泛，但远非全面：Rust 是一门表面积很大的语言，生态系统更大！\
+不过别让这吓到你：**没必要学完所有东西**。
+你会**在做你自己的项目时**，逐渐掌握在你所在领域（后端、嵌入式、CLI、GUI 等）所需的内容。
 
-In the end, there are no shortcuts: if you want to get good at something,
-you need to do it, over and over again. Throughout this course you wrote a fair
-amount of Rust, enough to get the language and its syntax flowing under your
-fingers. It'll take many more lines of code to feel it "yours", but that moment
-will come without a doubt if you keep practicing.
+最后，没有捷径：要在某件事上变得在行，你必须一遍又一遍地做它。整门课程下来你写了相当数量的 Rust 代码，足以让语言和它的语法在你指尖流动起来。要再写很多行才会感觉它"是你自己的"，但只要你不断练习，那一刻一定会到来。
 
-## Going further
+## 走得更远 (Going further)
 
-Let's close with some pointers to additional resources that you might find
-useful as you move forward in your journey with Rust.
+最后给你一些指引，列出你在 Rust 之旅中可能用得上的额外资源。
 
-### Exercises
+### 练习 (Exercises)
 
-You can find more exercises to practice Rust in the [`rustlings`](https://github.com/rust-lang/rustlings)
-project and on [exercism.io](https://exercism.io)'s Rust track.
+更多 Rust 练习可以在 [`rustlings`](https://github.com/rust-lang/rustlings) 项目和 [exercism.io](https://exercism.io) 的 Rust 路径中找到。
 
-### Introductory material
+### 入门资料 (Introductory material)
 
-Check out [the Rust book](https://doc.rust-lang.org/book/title-page.html) and
-["Programming Rust"](https://www.oreilly.com/library/view/programming-rust-2nd/9781492052586/)
-if you're looking for a different perspective on the same concepts we covered throughout this course.
-You'll certainly learn something new since they don't cover exactly the same topics; Rust has a lot of surface area!
+如果你想从不同视角看本课程涵盖的概念，请看 [Rust 之书 (the Rust book)](https://doc.rust-lang.org/book/title-page.html) 和 ["Programming Rust"](https://www.oreilly.com/library/view/programming-rust-2nd/9781492052586/)。
+你肯定会学到新东西，因为它们涵盖的话题不完全相同；Rust 表面积很大！
 
-### Advanced material
+### 进阶资料 (Advanced material)
 
-If you want to dive deeper into the language, refer to the [Rustonomicon](https://doc.rust-lang.org/nomicon/)
-and ["Rust for Rustaceans"](https://nostarch.com/rust-rustaceans).\
-The ["Decrusted" series](https://www.youtube.com/playlist?list=PLqbS7AVVErFirH9armw8yXlE6dacF-A6z) is another excellent
-resource to learn more about the internals of many of the most popular Rust libraries.
+如果你想更深入这门语言，参考 [Rustonomicon](https://doc.rust-lang.org/nomicon/) 与 ["Rust for Rustaceans"](https://nostarch.com/rust-rustaceans)。\
+["Decrusted" 系列](https://www.youtube.com/playlist?list=PLqbS7AVVErFirH9armw8yXlE6dacF-A6z) 也是了解许多最流行 Rust 库内部细节的优秀资源。
 
-### Domain-specific material
+### 领域专门资料 (Domain-specific material)
 
-If you want to use Rust for backend development,
-check out ["Zero to Production in Rust"](https://zero2prod.com).\
-If you want to use Rust for embedded development,
-check out the [Embedded Rust book](https://docs.rust-embedded.org/book/).
+如果你想用 Rust 做后端开发，
+看看 ["Zero to Production in Rust"](https://zero2prod.com)。\
+如果你想用 Rust 做嵌入式开发，
+看看 [Embedded Rust book](https://docs.rust-embedded.org/book/)。
 
-### Masterclasses
+### 大师班 (Masterclasses)
 
-You can then find resources on key topics that cut across domains.\
-For testing, check out
-["Advanced testing, going beyond the basics"](https://rust-exercises.com/advanced-testing/).\
-For telemetry, check out ["You can't fix what you can't see"](https://rust-exercises.com/telemetry/).
+你还能找到一些跨领域核心话题的资源。\
+关于测试，看
+["Advanced testing, going beyond the basics"](https://rust-exercises.com/advanced-testing/)。\
+关于遥测 (telemetry)，看 ["You can't fix what you can't see"](https://rust-exercises.com/telemetry/)。
+
+> 原文链接：[英文原文](https://github.com/mainmatter/100-exercises-to-learn-rust/blob/main/book/src/going_further.md)


### PR DESCRIPTION
## 🎉 全书翻译完成（100/100）

进度：90/100 → 100/100（+10）

### 第 8 章：异步 Rust（9 篇）
async/await 基础 / spawn 与 JoinHandle / 运行时架构（多线程 vs 当前线程、work-stealing）/ Future 特质与状态机 / 不要阻塞运行时与 spawn_blocking / 异步感知原语（tokio::sync::Mutex 等）/ 取消机制 / 收尾

### 后记
going_further.md：进一步学习资源与领域指南

### 同步更新
- README checklist 全部勾选
- welcome.md 进度数 90% → 已翻译完成

## 全书统计
- 100 篇章节文档
- 8 章 + 引言 + 后记
- 8 个 PR 累计（#2、#4、#6、#7、#8 + 此 PR）

https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPswN6hGd5Te4NzqMVQHkA)_